### PR TITLE
Fix JAVA_HOME SCRIPT to support more linux distros

### DIFF
--- a/bin/hdfs-mesos-datanode
+++ b/bin/hdfs-mesos-datanode
@@ -11,6 +11,7 @@ elif [ -f $JAVA_HOME_DIR/../bin/java ];
 then
   export JAVA_HOME=$JAVA_HOME_DIR/..
 else 
+  echo “Error JAVA_HOME cannot be determined from the registry”
   exit 1;
 fi
 

--- a/bin/hdfs-mesos-journalnode
+++ b/bin/hdfs-mesos-journalnode
@@ -11,6 +11,7 @@ elif [ -f $JAVA_HOME_DIR/../bin/java ];
 then
   export JAVA_HOME=$JAVA_HOME_DIR/..
 else 
+  echo “Error JAVA_HOME cannot be determined from the registry”
   exit 1;
 fi
 

--- a/bin/hdfs-mesos-namenode
+++ b/bin/hdfs-mesos-namenode
@@ -11,6 +11,7 @@ elif [ -f $JAVA_HOME_DIR/../bin/java ];
 then
   export JAVA_HOME=$JAVA_HOME_DIR/..
 else 
+  echo “Error JAVA_HOME cannot be determined from the registry”
   exit 1;
 fi
 

--- a/bin/hdfs-mesos-zkfc
+++ b/bin/hdfs-mesos-zkfc
@@ -11,6 +11,7 @@ elif [ -f $JAVA_HOME_DIR/../bin/java ];
 then
   export JAVA_HOME=$JAVA_HOME_DIR/..
 else 
+  echo “Error JAVA_HOME cannot be determined from the registry”
   exit 1;
 fi
 


### PR DESCRIPTION
Add if else clause.

If the bin/java directory exists in a specific location, we know that
it is debian/ubuntu. Otherwise, it is rehl/centos
