### PR TITLE
Build/dependency cleanup

### DIFF
--- a/bin/build-hdfs
+++ b/bin/build-hdfs
@@ -19,7 +19,7 @@ fi
 
 # Build and package hdfs-mesos project
 if [ "$1" != "nocompile" ]; then
-  mvn clean package
+  mvn clean package || exit
 fi
 
 # Download hadoop binary

--- a/bin/build-hdfs
+++ b/bin/build-hdfs
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-HADOOP_DIR=hadoop-2.3.0-cdh5.1.0
+HADOOP_VER=2.3.0-cdh5.1.0
+HADOOP_DIR=hadoop-$HADOOP_VER
 HADOOP_ZIP=$HADOOP_DIR.tar.gz
 HADOOP_URL=http://archive.cloudera.com/cdh5/cdh/5/$HADOOP_ZIP
 NATIVE=native
@@ -30,21 +31,10 @@ else
     echo "($HADOOP_ZIP already exists, skipping dl)"
 fi
 
-# Extract hadoop, remove cruft
+# Extract hadoop
 if [ ! -d $HADOOP_DIR ]; then
     echo "Extracting $HADOOP_ZIP"
     tar xf $HADOOP_ZIP
-
-    # Remove unneeded files
-    cd $HADOOP_DIR
-    rm -rf cloudera
-    rm -rf examples*
-    rm -rf src
-    rm -rf share/hadoop/mapreduce*
-    rm -rf share/hadoop/yarn
-    rm -rf share/doc
-    rm -rf etc/hadoop-mapreduce*
-    cd ..
 else
     echo "($HADOOP_DIR already exists, skipping extract)"
 fi
@@ -61,21 +51,35 @@ else
     echo "($NATIVE libs already exist, skipping dl)"
 fi
 
-# Copy to dist
+# Create dist
 if [ ! -d $DIST ]; then
     echo "Creating new $DIST dist folder"
     mkdir -p $DIST
-    cp -R $HADOOP_DIR/* $DIST
 else
     echo "($DIST already exists, skipping create)"
 fi
+
+# Copy to dist
+echo "Copying required hadoop dependencies into $DIST"
+cp -R $HADOOP_DIR/bin $DIST
+cp -R $HADOOP_DIR/etc $DIST
+cp -R $HADOOP_DIR/libexec $DIST
+mkdir -p $DIST/share/hadoop/common
+cp -R $HADOOP_DIR/share/hadoop/common/hadoop-common-$HADOOP_VER.jar $DIST/share/hadoop/common
+cp -R $HADOOP_DIR/share/hadoop/common/lib $DIST/share/hadoop/common
+mkdir -p $DIST/share/hadoop/hdfs
+cp -R $HADOOP_DIR/share/hadoop/hdfs/hadoop-hdfs-$HADOOP_VER.jar $DIST/share/hadoop/hdfs
+cp -R $HADOOP_DIR/share/hadoop/hdfs/lib $DIST/share/hadoop/hdfs
+cp -R $HADOOP_DIR/share/hadoop/hdfs/webapps $DIST/share/hadoop/hdfs
+
+mkdir -p $DIST/lib/native
+cp $NATIVE/* $DIST/lib/native
 
 echo "Copying build output into $DIST"
 cd $DIST
 cp ../bin/* bin/
 cp ../target/*-uber.jar lib/
 cp ../conf/* etc/hadoop/
-cp ../$NATIVE/* lib/native
 cd ..
 
 # Compress tarball

--- a/bin/hdfs-mesos-namenode
+++ b/bin/hdfs-mesos-namenode
@@ -18,23 +18,17 @@ fi
 trap "{ $DIR/mesos-killtree "$$" ; exit 0; }" EXIT
 
 function bootstrap_standby() {
-  echo "Pausing for 10s before bootstrapping standby namenode"
-  sleep 10
   $DIR/hdfs zkfc -formatZK -force
   exec $DIR/hdfs namenode -bootstrapStandby -force
 }
 
 function format_namenode() {
   echo "Asked to format namenode"
-  echo "Pausing for 10s"
-  sleep 10
   $DIR/hdfs zkfc -formatZK -force
   $DIR/hdfs namenode -format -force || exit 3
 }
 
 function initialize_shared_edits() {
-  echo "Pausing before initializing shared edits"
-  sleep 10
   exec $DIR/hdfs namenode -initializeSharedEdits
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,6 @@
       <version>${hadoop.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>


### PR DESCRIPTION
- Fix log4j exception when starting scheduler
- Exit build-hdfs early if compile fails
- Copy required dependency directories, rather than deleting cruft
- Remove unnecessary sleeps