### PR TITLE
Redirect all logging through slflog4j to logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
 
     <java.abi>1.7</java.abi>
     <mesos.version>0.20.0</mesos.version>
+    <log4j-over-slf4j.version>1.7.10</log4j-over-slf4j.version>
+    <slf4j-simple.version>1.7.10</slf4j-simple.version>
     <hadoop.version>2.4.0</hadoop.version>
     <jetty.version>9.2.2.v20140723</jetty.version>
     <joda-time.version>2.4</joda-time.version>
@@ -47,10 +49,30 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${log4j-over-slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j-simple.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
 
     <java.abi>1.7</java.abi>
     <mesos.version>0.20.0</mesos.version>
-    <log4j-over-slf4j.version>1.7.10</log4j-over-slf4j.version>
-    <jcl-over-slf4j.version>1.7.10</jcl-over-slf4j.version>
+    <slf4j.version>1.7.10</slf4j.version>
     <logback-classic.version>1.1.2</logback-classic.version>
     <hadoop.version>2.4.0</hadoop.version>
     <jetty.version>9.2.2.v20140723</jetty.version>
@@ -52,13 +51,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>${log4j-over-slf4j.version}</version>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>${jcl-over-slf4j.version}</version>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
     <java.abi>1.7</java.abi>
     <mesos.version>0.20.0</mesos.version>
     <log4j-over-slf4j.version>1.7.10</log4j-over-slf4j.version>
-    <slf4j-simple.version>1.7.10</slf4j-simple.version>
+    <jcl-over-slf4j.version>1.7.10</jcl-over-slf4j.version>
+    <logback-classic.version>1.1.2</logback-classic.version>
     <hadoop.version>2.4.0</hadoop.version>
     <jetty.version>9.2.2.v20140723</jetty.version>
     <joda-time.version>2.4</joda-time.version>
@@ -56,8 +57,14 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j-simple.version}</version>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${jcl-over-slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback-classic.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This redirects all logging to log4j and cjl to slf4j and adds logback classic as the log output. There should probably be a config to turn off the jetty debug logs.