### PR TITLE
Distribute hdfs binaries

### DIFF
--- a/src/main/java/org/apache/mesos/hdfs/config/SchedulerConf.java
+++ b/src/main/java/org/apache/mesos/hdfs/config/SchedulerConf.java
@@ -138,6 +138,10 @@ public class SchedulerConf extends MainConf {
     return getConf().get("mesos.hdfs.secondary.data.dir", "/var/run/hadoop-hdfs");
   }
 
+  public String getFrameworkMountPath() {
+    return getConf().get("mesos.hdfs.framework.mnt.path", "/opt/mesosphere/");
+  }
+
   public String getConfigPath() {
     return getConf().get("mesos.hdfs.config.path", "etc/hadoop/hdfs-site.xml");
   }

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -107,9 +107,9 @@ public abstract class AbstractNodeExecutor implements Executor {
       Path sandboxHdfsBinaryPath = Paths.get(sandboxHdfsBinary.getAbsolutePath());
 
       // Create mesosphere opt dir (parent dir of the symbolic link) if it does not exist
-      File mesosphereOptDir = new File(schedulerConf.getFrameworkMountPath());
-      if (!mesosphereOptDir.exists()) {
-        mesosphereOptDir.mkdirs();
+      File frameworkMountDir = new File(schedulerConf.getFrameworkMountPath());
+      if (!frameworkMountDir.exists()) {
+        frameworkMountDir.mkdirs();
       }
 
       // Delete and recreate directory for symbolic link every time
@@ -123,6 +123,8 @@ public abstract class AbstractNodeExecutor implements Executor {
       // Create symbolic link
       Path hdfsLinkDirPath = Paths.get(hdfsBinaryPath);
       Files.createSymbolicLink(hdfsLinkDirPath, sandboxHdfsBinaryPath);
+      log.info("The linked HDFS binary path is: " + sandboxHdfsBinaryPath);
+      log.info("The symbolic link path is: " + hdfsLinkDirPath);
     } catch (Exception e) {
       log.error("Error creating the symbolic link to hdfs binary: " + e);
     }

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -12,6 +12,7 @@ import org.apache.mesos.MesosExecutorDriver;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.hdfs.config.SchedulerConf;
 import org.apache.mesos.hdfs.ProdConfigModule;
+import org.apache.mesos.hdfs.util.HDFSConstants;
 import org.apache.mesos.hdfs.util.StreamRedirect;
 
 import java.io.File;
@@ -99,23 +100,26 @@ public abstract class AbstractNodeExecutor implements Executor {
    * Create Symbolc Link for the HDFS binary.
    **/
   private void createSymbolicLink() {
-    log.info("Create symbolic link for HDFS binary");
+    log.info("Creating a symbolic link for HDFS binary");
     try {
       // Get hdfs executable direcotry
-      File hadoopBinary = new File(System.getProperty("user.dir"));
-      Path hadoopBinaryPath = Paths.get(hadoopBinary.getAbsolutePath());
+      File sandboxHdfsBinary = new File(System.getProperty("user.dir"));
+      Path sandboxHdfsBinaryPath = Paths.get(sandboxHdfsBinary.getAbsolutePath());
 
-      // Delete and recreate directory for symbolic link
-      String linkPath = "/opt/mesosphere/hadoop";
-      File linkDir = new File(linkPath);
-      if (linkDir.exists()) {
-        deleteFile(linkDir);
+      // Delete and recreate directory for symbolic link every time
+      File hdfsBinaryDir = new File(HDFSConstants.HDFS_BINARY_PATH);
+      File baseDir = new File(HDFSConstants.MESOSPHERE_OPT_PATH);
+      if (hdfsBinaryDir.exists()) {
+        deleteFile(hdfsBinaryDir);
+      } else if (!baseDir.exists()) {
+        baseDir.mkdirs();
       }
 
-      Path linkDirPath = Paths.get(linkPath);
-      Files.createSymbolicLink(linkDirPath, hadoopBinaryPath);
+      // Create symbolic link
+      Path linkDirPath = Paths.get(HDFSConstants.HDFS_BINARY_PATH);
+      Files.createSymbolicLink(linkDirPath, sandboxHdfsBinaryPath);
     } catch (Exception e) {
-      log.error("Error creating the sym link to hdfs binary: " + e);
+      log.error("Error creating the symbolic link to hdfs binary: " + e);
     }
   }
   /**

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -107,19 +107,21 @@ public abstract class AbstractNodeExecutor implements Executor {
       Path sandboxHdfsBinaryPath = Paths.get(sandboxHdfsBinary.getAbsolutePath());
 
       // Create mesosphere opt dir (parent dir of the symbolic link) if it does not exist
-      File mesosphereOptDir = new File(HDFSConstants.MESOSPHERE_OPT_PATH);
+      File mesosphereOptDir = new File(schedulerConf.getFrameworkMountPath());
       if (!mesosphereOptDir.exists()) {
         mesosphereOptDir.mkdirs();
       }
 
       // Delete and recreate directory for symbolic link every time
-      File hdfsBinaryDir = new File(HDFSConstants.HDFS_BINARY_PATH);
+      String hdfsBinaryPath = schedulerConf.getFrameworkMountPath()
+          + HDFSConstants.HDFS_BINARY_DIR;
+      File hdfsBinaryDir = new File(hdfsBinaryPath);
       if (hdfsBinaryDir.exists()) {
         deleteFile(hdfsBinaryDir);
       }
 
       // Create symbolic link
-      Path hdfsLinkDirPath = Paths.get(HDFSConstants.HDFS_BINARY_PATH);
+      Path hdfsLinkDirPath = Paths.get(hdfsBinaryPath);
       Files.createSymbolicLink(hdfsLinkDirPath, sandboxHdfsBinaryPath);
     } catch (Exception e) {
       log.error("Error creating the symbolic link to hdfs binary: " + e);

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -97,7 +97,7 @@ public abstract class AbstractNodeExecutor implements Executor {
   }
 
   /**
-   * Create Symbolc Link for the HDFS binary.
+   * Create Symbolic Link for the HDFS binary.
    **/
   private void createSymbolicLink() {
     log.info("Creating a symbolic link for HDFS binary");

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -102,7 +102,7 @@ public abstract class AbstractNodeExecutor implements Executor {
   private void createSymbolicLink() {
     log.info("Creating a symbolic link for HDFS binary");
     try {
-      // Get hdfs executable direcotry
+      // Find Hdfs binary in sandbox
       File sandboxHdfsBinary = new File(System.getProperty("user.dir"));
       Path sandboxHdfsBinaryPath = Paths.get(sandboxHdfsBinary.getAbsolutePath());
 
@@ -111,11 +111,13 @@ public abstract class AbstractNodeExecutor implements Executor {
       if (!mesosphereOptDir.exists()) {
         mesosphereOptDir.mkdirs();
       }
+
       // Delete and recreate directory for symbolic link every time
       File hdfsBinaryDir = new File(HDFSConstants.HDFS_BINARY_PATH);
       if (hdfsBinaryDir.exists()) {
         deleteFile(hdfsBinaryDir);
       }
+
       // Create symbolic link
       Path hdfsLinkDirPath = Paths.get(HDFSConstants.HDFS_BINARY_PATH);
       Files.createSymbolicLink(hdfsLinkDirPath, sandboxHdfsBinaryPath);

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -106,18 +106,19 @@ public abstract class AbstractNodeExecutor implements Executor {
       File sandboxHdfsBinary = new File(System.getProperty("user.dir"));
       Path sandboxHdfsBinaryPath = Paths.get(sandboxHdfsBinary.getAbsolutePath());
 
+      // Create mesosphere opt dir (parent dir of the symbolic link) if it does not exist
+      File mesosphereOptDir = new File(HDFSConstants.MESOSPHERE_OPT_PATH);
+      if (!mesosphereOptDir.exists()) {
+        mesosphereOptDir.mkdirs();
+      }
       // Delete and recreate directory for symbolic link every time
       File hdfsBinaryDir = new File(HDFSConstants.HDFS_BINARY_PATH);
-      File baseDir = new File(HDFSConstants.MESOSPHERE_OPT_PATH);
       if (hdfsBinaryDir.exists()) {
         deleteFile(hdfsBinaryDir);
-      } else if (!baseDir.exists()) {
-        baseDir.mkdirs();
       }
-
       // Create symbolic link
-      Path linkDirPath = Paths.get(HDFSConstants.HDFS_BINARY_PATH);
-      Files.createSymbolicLink(linkDirPath, sandboxHdfsBinaryPath);
+      Path hdfsLinkDirPath = Paths.get(HDFSConstants.HDFS_BINARY_PATH);
+      Files.createSymbolicLink(hdfsLinkDirPath, sandboxHdfsBinaryPath);
     } catch (Exception e) {
       log.error("Error creating the symbolic link to hdfs binary: " + e);
     }

--- a/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
+++ b/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
@@ -22,4 +22,8 @@ public class HDFSConstants {
   public static final String NODE_EXECUTOR_ID = "NodeExecutor";
   public static final String NAME_NODE_EXECUTOR_ID = "NameNodeExecutor";
 
+  // Path to Store HDFS Binary
+  public static final String MESOSPHERE_OPT_PATH = "/opt/mesosphere/";
+  public static final String HDFS_BINARY_PATH = MESOSPHERE_OPT_PATH + "hadoop";
+
 }

--- a/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
+++ b/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
@@ -23,6 +23,6 @@ public class HDFSConstants {
   public static final String NAME_NODE_EXECUTOR_ID = "NameNodeExecutor";
 
   // Path to Store HDFS Binary
-  public static final String HDFS_BINARY_DIR = "hadoop";
+  public static final String HDFS_BINARY_DIR = "hdfs";
 
 }

--- a/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
+++ b/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
@@ -23,7 +23,6 @@ public class HDFSConstants {
   public static final String NAME_NODE_EXECUTOR_ID = "NameNodeExecutor";
 
   // Path to Store HDFS Binary
-  public static final String MESOSPHERE_OPT_PATH = "/opt/mesosphere/";
-  public static final String HDFS_BINARY_PATH = MESOSPHERE_OPT_PATH + "hadoop";
+  public static final String HDFS_BINARY_DIR = "hadoop";
 
 }


### PR DESCRIPTION
The executor will automatically add a symbolic link to the HDFS binaries in /opt/mesosphere/hadoop. It will recreate this symbolic link each time to make sure it is current.