### PR TITLE
Update Config Server to distribute HDFS binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Starting HDFS-Mesos
 
 Using HDFS
 --------------------------
-See some of the many HDFS tutorials out there for more details, but here's a quick sanity check:
+See some of the many HDFS tutorials out there for more details and explore the web UI at http://<ActiveNameNode>:50070.
+Also here is a quick sanity check:
 
 1. `hadoop fs -ls hdfs://<ActiveNameNode>:50071/` should show nothing for starters
 2. `hadoop fs -put /path/to/src_file hdfs://<ActiveNameNode>:50071/`

--- a/src/main/java/org/apache/mesos/hdfs/Scheduler.java
+++ b/src/main/java/org/apache/mesos/hdfs/Scheduler.java
@@ -128,8 +128,8 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
                     HDFSConstants.HDFS_BINARY_FILE_NAME))
                 .build(),
             CommandInfo.URI.newBuilder().setValue(
-                String.format("http://%s:%d/%s", conf.getFrameworkHostAddress(), confServerPort),
-                    HDFSConstants.HDFS_CONFIG_FILE_NAME)
+                String.format("http://%s:%d/%s", conf.getFrameworkHostAddress(), confServerPort,
+                    HDFSConstants.HDFS_CONFIG_FILE_NAME))
                 .build()))
             .setEnvironment(Environment.newBuilder()
                 .addAllVariables(Arrays.asList(

--- a/src/main/java/org/apache/mesos/hdfs/Scheduler.java
+++ b/src/main/java/org/apache/mesos/hdfs/Scheduler.java
@@ -124,10 +124,12 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
         .setCommand(CommandInfo.newBuilder()
         .addAllUris(Arrays.asList(
             CommandInfo.URI.newBuilder().setValue(
-                conf.getExecUri())
+                String.format("http://%s:%d/%s", conf.getFrameworkHostAddress(), confServerPort,
+                    HDFSConstants.HDFS_BINARY_FILE_NAME))
                 .build(),
             CommandInfo.URI.newBuilder().setValue(
-                String.format("http://%s:%d/hdfs-site.xml", conf.getFrameworkHostAddress(), confServerPort))
+                String.format("http://%s:%d/%s", conf.getFrameworkHostAddress(), confServerPort),
+                    HDFSConstants.HDFS_CONFIG_FILE_NAME)
                 .build()))
             .setEnvironment(Environment.newBuilder()
                 .addAllVariables(Arrays.asList(

--- a/src/main/java/org/apache/mesos/hdfs/config/ConfigServer.java
+++ b/src/main/java/org/apache/mesos/hdfs/config/ConfigServer.java
@@ -3,9 +3,12 @@ package org.apache.mesos.hdfs.config;
 import com.floreysoft.jmte.Engine;
 import com.google.inject.Inject;
 import org.apache.mesos.hdfs.state.LiveState;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -29,7 +32,12 @@ public class ConfigServer {
     this.liveState = liveState;
     engine = new Engine();
     server = new Server(schedulerConf.getConfigServerPort());
-    server.setHandler(new ServeHdfsConfigHandler());
+    ResourceHandler resourceHandler = new ResourceHandler();
+    resourceHandler.setResourceBase(schedulerConf.getExecutorPath());
+    HandlerList handlers = new HandlerList();
+    handlers.setHandlers(new Handler[]{
+        resourceHandler, new ServeHdfsConfigHandler()});
+    server.setHandler(handlers);
     server.start();
   }
 
@@ -84,8 +92,8 @@ public class ConfigServer {
       content = engine.transform(content, model);
 
       response.setContentType("application/octet-stream;charset=utf-8");
-      response
-          .setHeader("Content-Disposition", "attachment; filename=\"" + "hdfs-site.xml" + "\" ");
+      response.setHeader("Content-Disposition", "attachment; filename=\"" +
+          HDFSConstants.HDFS_CONFIG_FILE_NAME + "\" ");
       response.setHeader("Content-Transfer-Encoding", "binary");
       response.setHeader("Content-Length", Integer.toString(content.length()));
 

--- a/src/main/java/org/apache/mesos/hdfs/config/ConfigServer.java
+++ b/src/main/java/org/apache/mesos/hdfs/config/ConfigServer.java
@@ -3,6 +3,7 @@ package org.apache.mesos.hdfs.config;
 import com.floreysoft.jmte.Engine;
 import com.google.inject.Inject;
 import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.util.HDFSConstants;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;

--- a/src/main/java/org/apache/mesos/hdfs/config/SchedulerConf.java
+++ b/src/main/java/org/apache/mesos/hdfs/config/SchedulerConf.java
@@ -26,6 +26,10 @@ public class SchedulerConf extends Configured {
     setConf(configuration);
   }
 
+  public String getExecutorPath() {
+    return getConf().get("mesos.hdfs.executor.config.path", "..");
+  }
+
   public String getConfigPath() {
     return getConf().get("mesos.hdfs.config.path", "etc/hadoop/hdfs-site.xml");
   }
@@ -125,12 +129,6 @@ public class SchedulerConf extends Configured {
 
   public int getJournalNodeCount() {
     return getConf().getInt("mesos.hdfs.journalnode.count", 1);
-  }
-
-  // TODO(elingg) This will be removed once https://github.com/mesosphere/hdfs/pull/44 is merged
-  public String getExecUri() {
-    return getConf().get("mesos.hdfs.executor.uri",
-        "https://s3-us-west-1.amazonaws.com/mesosphere-executors-public/hdfs-mesos-0.0.2.tgz");
   }
 
   public String getClusterName() {

--- a/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
+++ b/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
@@ -24,5 +24,11 @@ public class HDFSConstants {
 
   // Path to Store HDFS Binary
   public static final String HDFS_BINARY_DIR = "hdfs";
+    
+  // Current HDFS Binary File Name
+  public static final String HDFS_BINARY_FILE_NAME = "hdfs-mesos-0.0.2.tgz";
+    
+  //HDFS Config File Name
+  public static final String HDFS_CONFIG_FILE_NAME = "hdfs-site.xml";
 
 }


### PR DESCRIPTION
This avoids use of the AWS bucket and closes https://github.com/mesosphere/hdfs/issues/62 and https://github.com/mesosphere/hdfs/issues/38.