### PR TITLE
The following scenarios for errorred/lost tasks now work with this patch

### DIFF
--- a/src/main/java/org/apache/mesos/hdfs/Scheduler.java
+++ b/src/main/java/org/apache/mesos/hdfs/Scheduler.java
@@ -142,12 +142,18 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
           }
           break;
         case FORMAT_NAME_NODES :
-          if (!liveState.isNameNode1Initialized()) {
+          if (!liveState.isNameNode1Initialized() && !liveState.isNameNode2Initialized()) {
             sendMessageTo(
                 driver,
                 liveState.getFirstNameNodeTaskId(),
                 liveState.getFirstNameNodeSlaveId(),
                 HDFSConstants.NAME_NODE_INIT_MESSAGE);
+          } else if (!liveState.isNameNode1Initialized()) {
+            sendMessageTo(
+                driver,
+                liveState.getFirstNameNodeTaskId(),
+                liveState.getFirstNameNodeSlaveId(),
+                HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE);
           } else if (!liveState.isNameNode2Initialized()) {
             sendMessageTo(
                 driver,
@@ -545,8 +551,8 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
   }
 
   private void reconcileTasks(SchedulerDriver driver) {
-    //TODO run this method repeatedly with exponential backoff in the case that it takes time for
-    //different slaves to reregister upon master failover.
+    // TODO run this method repeatedly with exponential backoff in the case that it takes time for
+    // different slaves to reregister upon master failover.
     reconciliationCompleted = false;
     driver.reconcileTasks(Collections.<Protos.TaskStatus> emptyList());
     Timer timer = new Timer();

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -77,7 +77,7 @@ public abstract class AbstractNodeExecutor implements Executor {
   /**
    * Delete a file or directory.
    **/
-  private void deleteFile(File fileToDelete) {
+  protected void deleteFile(File fileToDelete) {
     if (fileToDelete.isDirectory()) {
       String[] entries = fileToDelete.list();
       for (String entry : entries) {

--- a/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
@@ -99,13 +99,12 @@ public class NameNodeExecutor extends AbstractNodeExecutor {
     File nameDir = new File(schedulerConf.getDataDir() + "/name");
     if (messageStr.equals(HDFSConstants.NAME_NODE_INIT_MESSAGE)
         || messageStr.equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)) {
-      if (nameDir.exists()) {
-        // TODO (elingg) test failure scenario to make sure NN restarts with the
-        // appropriate sequence of events
+      if (nameDir.exists() && messageStr.equals(HDFSConstants.NAME_NODE_INIT_MESSAGE)) {
         log.info(String
             .format("NameNode data directory %s already exists, not formatting",
                 nameDir));
       } else {
+        deleteFile(nameDir);
         nameDir.mkdirs();
         runCommand(driver, nameNodeTask, "bin/hdfs-mesos-namenode " + messageStr);
         startProcess(driver, nameNodeTask);

--- a/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
+++ b/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
@@ -64,17 +64,26 @@ public class LiveState {
   public void updateTaskForStatus(Protos.TaskStatus status) {
     //Case of name node, update the task map
     if (status.getTaskId().getValue().contains(HDFSConstants.NAME_NODE_TASKID)) {
+      //If initializing the first NN or reconciling the first NN or bootstrapping the first NN
+      //set the status to initialized
       if (status.getMessage().equals(HDFSConstants.NAME_NODE_INIT_MESSAGE)
           || (currentAcquisitionPhase.equals(AcquisitionPhase.RECONCILING_TASKS)
-          && !isNameNode1Initialized())) {
+              && !isNameNode1Initialized())
+          || (status.getMessage().equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)
+              && !isNameNode1Initialized())) {
         nameNode1TaskMap.clear();
         nameNode1TaskMap.put(status, true);
-      } else if (status.getMessage().equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)
-          || currentAcquisitionPhase.equals(AcquisitionPhase.RECONCILING_TASKS)) {
+        //If bootstrapping the second NN or reconciling the second NN, set the status to initialized
+      } else if ((status.getMessage().equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)
+          && !isNameNode2Initialized())
+          || (currentAcquisitionPhase.equals(AcquisitionPhase.RECONCILING_TASKS)
+              && !isNameNode2Initialized())) {
         nameNode2TaskMap.clear();
         nameNode2TaskMap.put(status, true);
+        //If the first NN is not running, set the status to running
       } else if (nameNode1TaskMap.isEmpty()) {
         nameNode1TaskMap.put(status, false);
+        //If the second NN is not running, set the status to running
       } else if (nameNode2TaskMap.isEmpty()) {
         nameNode2TaskMap.put(status, false);
       }

--- a/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
+++ b/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
@@ -62,10 +62,14 @@ public class LiveState {
   }
 
   public void updateTaskForStatus(Protos.TaskStatus status) {
-    //Case of name node, update the task map
+    // TODO (elingg) Use Starting Status when the task is running, but not initialized. Use running
+    // status when the task is initialized so that we can differentiate during the reconciliation
+    // phase. Also, add the health checks which will kill the task if it doesn't properly
+    // initialize or if it reaches an error state.
+    // Case of name node, update the task map
     if (status.getTaskId().getValue().contains(HDFSConstants.NAME_NODE_TASKID)) {
-      //If initializing the first NN or reconciling the first NN or bootstrapping the first NN
-      //set the status to initialized
+      // If initializing the first NN or reconciling the first NN or bootstrapping the first NN
+      // set the status to initialized
       if (status.getMessage().equals(HDFSConstants.NAME_NODE_INIT_MESSAGE)
           || (currentAcquisitionPhase.equals(AcquisitionPhase.RECONCILING_TASKS)
               && !isNameNode1Initialized())
@@ -73,18 +77,19 @@ public class LiveState {
               && !isNameNode1Initialized())) {
         nameNode1TaskMap.clear();
         nameNode1TaskMap.put(status, true);
-        //If bootstrapping the second NN or reconciling the second NN, set the status to initialized
-      } else if ((status.getMessage().equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)
+      } // If bootstrapping the second NN or reconciling the second NN,
+        // set the status to initialized
+      else if ((status.getMessage().equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)
           && !isNameNode2Initialized())
           || (currentAcquisitionPhase.equals(AcquisitionPhase.RECONCILING_TASKS)
               && !isNameNode2Initialized())) {
         nameNode2TaskMap.clear();
         nameNode2TaskMap.put(status, true);
-        //If the first NN is not running, set the status to running
-      } else if (nameNode1TaskMap.isEmpty()) {
+      } // If the first NN is not running, set the status to running
+       else if (nameNode1TaskMap.isEmpty()) {
         nameNode1TaskMap.put(status, false);
-        //If the second NN is not running, set the status to running
-      } else if (nameNode2TaskMap.isEmpty()) {
+      } // If the second NN is not running, set the status to running
+       else if (nameNode2TaskMap.isEmpty()) {
         nameNode2TaskMap.put(status, false);
       }
     }


### PR DESCRIPTION
* Restarting Framework
* JN Standalone
* JN Colocated
* DN
* 2 DNS
* Active NN
* Standby NN
* JN + NN Not Colocated