### PR TITLE
Unlink hadoop binary before creating new symlink

### DIFF
--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -114,6 +114,9 @@ public abstract class AbstractNodeExecutor implements Executor {
           Process process = Runtime.getRuntime().exec("unlink " + hdfsBinaryPath);
           redirectProcess(process);
           int exitCode = process.waitFor();
+          if (exitCode != 0) {
+            log.error("Unable to unlink old sym link. Exit code: " + exitCode);
+          }
         } catch (IOException e) {
           log.fatal(e);
           System.exit(1);

--- a/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -109,6 +109,16 @@ public abstract class AbstractNodeExecutor implements Executor {
           + "/" + HDFSConstants.HDFS_BINARY_DIR;
       File hdfsBinaryDir = new File(hdfsBinaryPath);
       if (hdfsBinaryDir.exists()) {
+        //unlink the file
+        try {
+          Process process = Runtime.getRuntime().exec("unlink " + hdfsBinaryPath);
+          redirectProcess(process);
+          int exitCode = process.waitFor();
+        } catch (IOException e) {
+          log.fatal(e);
+          System.exit(1);
+        }
+        //delete the file
         deleteFile(hdfsBinaryDir);
       }
 


### PR DESCRIPTION
With this fix the following scenarios work successfully:
* Restarting Framework
* JN Standalone
* JN Colocated
* DN
* 2 DNS
* Active NN
* Standby NN
* JN + NN Not Colocated
* 2 JNS
* ZKFC
* JN + NN Colocated
* Both NNS

I tested killing both the executors and the processes (HDFS nodes themselves) separately. Fortunately the actually HDFS nodes restart themselves with the shell scripts, which is smooth failure handling.

We still need to test taking the full machine down so nodes cannot
recover on the same machine. I will be testing that with a subsequent
PR. I will also create issues for failure cases which we need to handle
by using a NN backup image (i.e. both machine holding the NN’s go down
and we need to start them on new machines).