### PR TITLE
Fix reconciliation features

### DIFF
--- a/src/main/java/org/apache/mesos/hdfs/Scheduler.java
+++ b/src/main/java/org/apache/mesos/hdfs/Scheduler.java
@@ -603,9 +603,9 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
     @Override
     public void run() {
       log.info("Current persistent state:");
-      log.info(String.format("JournalNodes: %s %s", persistentState.getJournalNodes(),
+      log.info(String.format("JournalNodes: %s, %s", persistentState.getJournalNodes(),
           persistentState.getJournalNodeTaskNames()));
-      log.info(String.format("NameNodes: %s %s", persistentState.getNameNodes(),
+      log.info(String.format("NameNodes: %s, %s", persistentState.getNameNodes(),
           persistentState.getNameNodeTaskNames()));
       log.info(String.format("DataNodes: %s", persistentState.getDataNodes()));
 
@@ -618,7 +618,6 @@ public class Scheduler implements org.apache.mesos.Scheduler, Runnable {
           persistentState.removeTaskId(taskId);
         }
       }
-      persistentState.resetDeadNodeTimeStamps();
       reconciliationCompleted = true;
     }
   }

--- a/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
+++ b/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
@@ -22,6 +22,7 @@ public class LiveState {
   private Set<Protos.TaskID> stagingTasks = new HashSet<>();
   private AcquisitionPhase currentAcquisitionPhase = AcquisitionPhase.RECONCILING_TASKS;
   // TODO (nicgrayson) Might need to split this out to jns, nns, and dns if dns too big
+  //TODO (elingg) we need to also track ZKFC's state
   private LinkedHashMap<String, Protos.TaskStatus> runningTasks = new LinkedHashMap<>();
   private HashMap<Protos.TaskStatus, Boolean> nameNode1TaskMap = new HashMap<>();
   private HashMap<Protos.TaskStatus, Boolean> nameNode2TaskMap = new HashMap<>();

--- a/src/main/java/org/apache/mesos/hdfs/state/PersistentState.java
+++ b/src/main/java/org/apache/mesos/hdfs/state/PersistentState.java
@@ -42,6 +42,7 @@ public class PersistentState {
   private static final String JOURNALNODE_TASKNAMES_KEY = "journalNodeTaskNames";
   private ZooKeeperState zkState;
   private SchedulerConf conf;
+  // TODO (elingg) we need to also track ZKFC's state
 
   private Timestamp deadJournalNodeTimeStamp = null;
   private Timestamp deadNameNodeTimeStamp = null;
@@ -53,6 +54,7 @@ public class PersistentState {
     this.zkState = new ZooKeeperState(conf.getStateZkServers(),
         conf.getStateZkTimeout(), TimeUnit.MILLISECONDS, "/hdfs-mesos/" + conf.getFrameworkName());
     this.conf = conf;
+    resetDeadNodeTimeStamps();
   }
 
   public FrameworkID getFrameworkID() throws InterruptedException, ExecutionException,
@@ -72,7 +74,7 @@ public class PersistentState {
     zkState.store(value).get();
   }
 
-  public void resetDeadNodeTimeStamps() {
+  private void resetDeadNodeTimeStamps() {
     Date date = DateUtils.addSeconds(new Date(), conf.getDeadNodeTimeout());
 
     if (getDeadJournalNodes().size() > 0) {

--- a/src/test/java/org/apache/mesos/hdfs/TestScheduler.java
+++ b/src/test/java/org/apache/mesos/hdfs/TestScheduler.java
@@ -209,6 +209,8 @@ public class TestScheduler {
 
   @Test
   public void removesTerminalTasksFromLiveState() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(AcquisitionPhase.DATA_NODES);
+
     scheduler.statusUpdate(driver, createTaskStatus(createTaskId("0"),
         Protos.TaskState.TASK_FAILED));
     scheduler.statusUpdate(driver, createTaskStatus(createTaskId("1"),


### PR DESCRIPTION
-Update timeout for dead nodes upon scheduler failover
-Make sure list of persistent tasks is accurate
-Better logging