### PR TITLE
Fix Scheduler Classpath

### DIFF
--- a/bin/hdfs-mesos
+++ b/bin/hdfs-mesos
@@ -14,4 +14,4 @@ else
   JAVA_CMD=$JAVA_HOME/bin/java
 fi
 
-exec $JAVA_CMD -cp lib/*.jar -Dmesos.conf.path=etc/hadoop/mesos-site.xml -Dmesos.hdfs.config.server.port=$PORT0 org.apache.mesos.hdfs.scheduler.Main
+exec $JAVA_CMD -cp ../lib/*.jar -Dmesos.conf.path=etc/hadoop/mesos-site.xml -Dmesos.hdfs.config.server.port=$PORT0 org.apache.mesos.hdfs.scheduler.Main


### PR DESCRIPTION
The scheduler's classpath wasn't correctly referencing the lib directory
which is a sibling not a child directory of the hdfs-mesos script