### PR TITLE
Package Java and Hadoop with HDFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out/
 # gradle
 .gradle
 build/
+
+# vim swap files
+*.swp

--- a/bin/build-hdfs
+++ b/bin/build-hdfs
@@ -126,6 +126,19 @@ cp $PROJ_DIR/hdfs-scheduler/build/libs/*-uber.jar $BUILD_DIR/$DIST/lib
 cp $BUILD_CACHE_DIR/$EXECUTOR.tgz $BUILD_DIR/$DIST
 mkdir -p $BUILD_DIR/$DIST/etc/hadoop
 cp $PROJ_DIR/conf/*.xml $BUILD_DIR/$DIST/etc/hadoop
+
+echo "Copying required hadoop dependencies into $BUILD_DIR/$DIST for the scheduler"
+cp $BUILD_CACHE_DIR/$HADOOP_DIR/bin/* $BUILD_DIR/$DIST/bin
+cp $BUILD_CACHE_DIR/$HADOOP_DIR/etc/* $BUILD_DIR/$DIST/etc
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/libexec $BUILD_DIR/$DIST
+mkdir -p $BUILD_DIR/$DIST/share/hadoop/common
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/common/hadoop-common-$HADOOP_VER.jar $BUILD_DIR/$DIST/share/hadoop/common
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/common/lib $BUILD_DIR/$DIST/share/hadoop/common
+mkdir -p $BUILD_DIR/$DIST/share/hadoop/hdfs
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/hdfs/hadoop-hdfs-$HADOOP_VER.jar $BUILD_DIR/$DIST/share/hadoop/hdfs
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/hdfs/lib $BUILD_DIR/$DIST/share/hadoop/hdfs
+cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/hdfs/webapps $BUILD_DIR/$DIST/share/hadoop/hdfs
+
 cd $BUILD_DIR
 tar czf $DIST.tgz $DIST
 

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -37,6 +37,10 @@ public class HdfsFrameworkConfig {
   private static final int DEFAULT_RECONCILIATION_TIMEOUT = 30;
   private static final int DEFAULT_DEADNODE_TIMEOUT = 90;
 
+  private static final String DEFAULT_JRE_URL = "https://downloads.mesosphere.io/java/jre-7u76-linux-x64.tar.gz";
+  private static final String DEFAULT_JRE_VERSION = "jre1.7.0_76";
+  private static final String DEFAULT_LD_LIBRARY_PATH = "/opt/mesosphere/lib";
+
   private final Log log = LogFactory.getLog(HdfsFrameworkConfig.class);
 
   public HdfsFrameworkConfig(Configuration conf) {
@@ -273,5 +277,17 @@ public class HdfsFrameworkConfig {
 
   public int getDeadNodeTimeout() {
     return getConf().getInt("mesos.hdfs.deadnode.timeout.seconds", DEFAULT_DEADNODE_TIMEOUT);
+  }
+
+  public String getJreUrl() {
+    return getConf().get("mesos.hdfs.jre-url", DEFAULT_JRE_URL);
+  }
+
+  public String getLdLibraryPath() {
+    return getConf().get("mesos.hdfs.ld-library-path", DEFAULT_LD_LIBRARY_PATH);
+  }
+
+  public String getJreVersion() {
+    return getConf().get("mesos.hdfs.jre-version", DEFAULT_JRE_VERSION);
   }
 }


### PR DESCRIPTION
In the testing/continuous branch, frameworks have had their access to
the host's java and hadoop binaries/scripts revoked.  In order for
frameworks to use java and hadoop it must be packaged with the
framework.

This change along with changes made to the mesosphere/universe repo
packages the needed java and hadoop dependencies with the HDFS
framework.