### PR TITLE
Consistent Configs

### DIFF
--- a/example-conf/mesosphere-dcos/mesos-site.xml
+++ b/example-conf/mesosphere-dcos/mesos-site.xml
@@ -84,4 +84,9 @@
     <name>mesos.native.library</name>
     <value>/opt/mesosphere/lib/libmesos.so</value>
   </property>
+  
+  <property>
+    <name>mesos.hdfs.ld-library-path</name>
+    <value>/opt/mesosphere/lib</value>
+  </property>
 </configuration>

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -37,10 +37,6 @@ public class HdfsFrameworkConfig {
   private static final int DEFAULT_RECONCILIATION_TIMEOUT = 30;
   private static final int DEFAULT_DEADNODE_TIMEOUT = 90;
 
-  private static final String DEFAULT_JRE_URL = "https://downloads.mesosphere.io/java/jre-7u76-linux-x64.tar.gz";
-  private static final String DEFAULT_JRE_VERSION = "jre1.7.0_76";
-  private static final String DEFAULT_LD_LIBRARY_PATH = "/opt/mesosphere/lib";
-
   private final Log log = LogFactory.getLog(HdfsFrameworkConfig.class);
 
   public HdfsFrameworkConfig(Configuration conf) {
@@ -280,14 +276,14 @@ public class HdfsFrameworkConfig {
   }
 
   public String getJreUrl() {
-    return getConf().get("mesos.hdfs.jre-url", DEFAULT_JRE_URL);
+    return getConf().get("mesos.hdfs.jre-url", "https://downloads.mesosphere.io/java/jre-7u76-linux-x64.tar.gz");
   }
 
   public String getLdLibraryPath() {
-    return getConf().get("mesos.hdfs.ld-library-path", DEFAULT_LD_LIBRARY_PATH);
+    return getConf().get("mesos.hdfs.ld-library-path", "/usr/local/lib");
   }
 
   public String getJreVersion() {
-    return getConf().get("mesos.hdfs.jre-version", DEFAULT_JRE_VERSION);
+    return getConf().get("mesos.hdfs.jre-version", "jre1.7.0_76");
   }
 }


### PR DESCRIPTION
I missed a couple of things in reviewing the last PR so I am fixing
them here:

1) Our standard in HdfsFrameworkConfig is that numeric values are
constant, but strings are not. Probably strings should also be
constants, but meanwhile I wanted to make sure we are consistent. We
also might want to consider another class in the future to store these
constants

2) I realized our configurations need to be consistent. Running on linux,
which is what our open source users do, typically the mesos library
would be under /usr/local/lib and that is our default configuration. In
DCOS we have a different configuration. I have updated that.