### PR TITLE
 Fix readme so that users can set configuration at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ Starts 1 active NameNode (with JournalNode and ZKFC), 1 standby NN (+JN,ZKFC), 1
 
 Prerequisites
 --------------------------
-1. Install `tar`, `unzip`, `wget` in your build host. Set proxy for maven / gradle and wget if needed
-2. Install `curl` for all hosts in cluster
+1. Install `tar`, `unzip`, `wget` in your build host. Set proxy for maven / gradle and wget if needed.
+2. Install `curl` for all hosts in cluster.
 3. `$JAVA_HOME` needs to be set on the host running your HDFS scheduler. This can be set through setting the environment variable on the host, `export JAVA_HOME=/path/to/jre`, or specifying the environment variable in Marathon.
 
 **NOTE:** The build process current supports maven and gradle.   The gradle wrapper meta-data is included in the project and is self boot-straping (meaning it isn't a prerequisite install).  Maven as the build system is being deprecated.
 
 Building HDFS-Mesos
 --------------------------
-1. `./bin/build-hdfs`
-2. Run `./bin/build-hdfs nocompile` to skip the `gradlew clean package` step and just re-bundle the binaries.
-3. To remove the project build output and downloaded binaries, run `./bin/build-hdfs clean`
+1. Customize configuration in `conf/*-site.xml`. All configuration files updated here will be used by the scheduler and also bundled with the executors.
+2. `./bin/build-hdfs`
+3. Run `./bin/build-hdfs nocompile` to skip the `gradlew clean package` step and just re-bundle the binaries.
+4. To remove the project build output and downloaded binaries, run `./bin/build-hdfs clean`.
 
 **NOTE:** The build process builds the artifacts under the `$PROJ_DIR/build` directory.  A number of zip and tar files are cached under the `cache` directory for faster subsequent builds.   The tarball used for installation is hdfs-mesos-x.x.x.tgz which contains the scheduler and the executor to be distributed.
 
@@ -23,9 +24,9 @@ Building HDFS-Mesos
 Installing HDFS-Mesos on your Cluster
 --------------------------
 1. Upload `hdfs-mesos-*.tgz` to a node in your Mesos cluster (which is built to `$PROJ_DIR/build/hdfs-mesos-x.x.x.tgz`).
-2. Extract it with `tar zxvf hdfs-mesos-*.tgz`
-3. Customize configuration in `hdfs-mesos-*/etc/hadoop/*-site.xml`
-4. Check that `hostname` on that node resolves to a non-localhost IP; update /etc/hosts if necessary
+2. Extract it with `tar zxvf hdfs-mesos-*.tgz`.
+3. Optional: Customize any additional configurations that weren't updated at compile time in `hdfs-mesos-*/etc/hadoop/*-site.xml` Note that if you update hdfs-site.xml, it will be used by the scheduler and bundled with the executors. However, core-site.xml and mesos-site.xml will be used by the scheduler only.
+4. Check that `hostname` on that node resolves to a non-localhost IP; update /etc/hosts if necessary.
 
 ### If you have Hadoop pre-installed in your cluster
 If you have Hadoop installed across your cluster, you don't need the Mesos scheduler application to distribute the binaries. You can set the `mesos.hdfs.native-hadoop-binaries` configuration parameter in `mesos-site.xml` if don't want the binaries distributed.


### PR DESCRIPTION
We need to allow for dynamic configuration at runtime and make use of
command line args or environment variables. Also, we can pass
configurations from the scheduler to the executors at runtime as
needed. This is part of our roadmap. Meanwhile, users often encounter
problems if their executors are not bundled with the proper
mesos-site.xml. I have updated the readme to account for this since a number of new users are complaining about this issue.