### PR TITLE
Enable Framework Authentication with CRAM-MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ Note: This will also remove task state, so you will want to manually kill any ru
 7. On each slave with the new settings, start the mesos slave by running
 <br>`sudo service mesos-slave start`.</br>
 
+Authentication with CRAM-MD5 (Optional)
+--------------------------
+1. In mesos-site.xml add the "mesos.hdfs.principal" and "mesos.hdfs.secret" properties. For example:
+```sh
+<property>
+  <name>mesos.hdfs.principal</name>
+  <value>hdfs</value>
+</property>
+
+<property>
+  <name>mesos.hdfs.secret</name>
+  <value>%ComplexPassword%123</value>
+</property>
+```
+
+2. Ensure that the Mesos master has access to the same credentials.  See the [Mesos configuration documentation](http://mesos.apache.org/documentation/latest/configuration/), in particular the --credentials flag.  Authentication defaults to CRAM-MD5 so setting the --authenticators flag is not necessary.
+
+
 Shutdown Instructions (Optional)
 --------------------------
 

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -61,6 +61,23 @@ public class HdfsFrameworkConfig {
     setConf(configuration);
   }
 
+  public String getPrincipal() {
+    return getConf().get("mesos.hdfs.principal", "");
+  }
+
+  public String getSecret() {
+    return getConf().get("mesos.hdfs.secret", "");
+  }
+
+  public boolean cramCredentialsEnabled() {
+    String principal = getPrincipal();
+    String secret = getSecret();
+    boolean principalExists = !principal.isEmpty();
+    boolean secretExists = !secret.isEmpty();
+
+    return principalExists && secretExists;
+  }
+
   public boolean usingMesosDns() {
     return Boolean.valueOf(getConf().get("mesos.hdfs.mesosdns", "false"));
   }


### PR DESCRIPTION
This change enables CRAM-MD5 authentication.  Since we are only
enabling a single authentication mechanism, its presence or absence
is used to determine the type of registration to use.  When more
authentication mechanisms are introduced a more sophisticated
approach to determining which authentication mechanism to use will
be needed.

This has been tested on DCOS clusters.  The Config changes refer to
configuration which does not exist in this change.  It has been tested
with that configuration present and absent, and works as expected.  The
framework fails authentication with incorrect credentials, succeeds with
correct credentials, and succeeds in registering without authentication
when the config is absent.

See this pull request for the changes required to make SASL
authentication operable in DCOS.

https://github.com/mesosphere/dcos-image/pull/74