### PR TITLE
Preserve file permissions when compressing

### DIFF
--- a/bin/build-hdfs
+++ b/bin/build-hdfs
@@ -142,7 +142,11 @@ cp $PROJ_DIR/hdfs-scheduler/build/libs/*-uber.jar $BUILD_DIR/$DIST/lib
 cp $BUILD_CACHE_DIR/$EXECUTOR.tgz $BUILD_DIR/$DIST
 cp $PROJ_DIR/conf/*.xml $BUILD_DIR/$DIST/etc/hadoop
 
+echo Adding read permissions to everything in and below $BUILD_DIR
 cd $BUILD_DIR
-tar czf $DIST.tgz $DIST
+chmod -R a+r .
+
+echo Creating $DIST.tgz while retaining permissions 
+tar pczf $DIST.tgz $DIST
 
 echo "HDFS framework build complete: $BUILD_DIR/$DIST.tgz"


### PR DESCRIPTION
Something changed the build behaviour of hdfs in TeamCity.  Required read permissions were being removed from files in the tarball.

I've tested this in TeamCity and locally and this forces read permissions on all files in all cases.