### PR TITLE
Improve Reconciliation

### DIFF
--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Observable;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -46,7 +47,7 @@ import java.util.TimerTask;
 /**
  * HDFS Mesos Framework Scheduler class implementation.
  */
-public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
+public class HdfsScheduler extends Observable implements org.apache.mesos.Scheduler, Runnable {
   // TODO (elingg) remove as much logic as possible from Scheduler to clean up code
   private final Log log = LogFactory.getLog(HdfsScheduler.class);
 
@@ -56,6 +57,7 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
   private final LiveState liveState;
   private final IPersistentStateStore persistenceStore;
   private final DnsResolver dnsResolver;
+  private final Reconciler reconciler;
 
   @Inject
   public HdfsScheduler(HdfsFrameworkConfig hdfsFrameworkConfig,
@@ -65,6 +67,9 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
     this.liveState = liveState;
     this.persistenceStore = persistenceStore;
     this.dnsResolver = new DnsResolver(this, hdfsFrameworkConfig);
+    this.reconciler = new Reconciler(persistenceStore);
+
+    addObserver(reconciler);
   }
 
   @Override
@@ -107,15 +112,13 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
       throw new SchedulerException(msg, e);
     }
     log.info("Registered framework frameworkId=" + frameworkId.getValue());
-    // reconcile tasks upon registration
-    reconcileTasks(driver);
+    reconciler.reconcile(driver);
   }
 
   @Override
   public void reregistered(SchedulerDriver driver, MasterInfo masterInfo) {
     log.info("Reregistered framework: starting task reconciliation");
-    // reconcile tasks upon reregistration
-    reconcileTasks(driver);
+    reconciler.reconcile(driver);
   }
 
   @Override
@@ -126,6 +129,10 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
       status.getState().toString(),
       status.getMessage(),
       liveState.getStagingTasksSize()));
+
+    log.info("Notifying observers");
+    setChanged();
+    notifyObservers(status);
 
     if (!isStagingState(status)) {
       liveState.removeStagingTask(status.getTaskId());
@@ -198,6 +205,10 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
   @Override
   public void resourceOffers(SchedulerDriver driver, List<Offer> offers) {
     log.info(String.format("Received %d offers", offers.size()));
+
+    if (reconciler.complete() && liveState.getCurrentAcquisitionPhase() == AcquisitionPhase.RECONCILING_TASKS) {
+      correctCurrentPhase();
+    }
 
     // TODO (elingg) within each phase, accept offers based on the number of nodes you need
     boolean acceptedOffer = false;
@@ -619,6 +630,11 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
   }
 
   private void correctCurrentPhase() {
+    if (!reconciler.complete()) {
+      liveState.transitionTo(AcquisitionPhase.RECONCILING_TASKS);
+      return;
+    }
+
     if (liveState.getJournalNodeSize() < hdfsFrameworkConfig.getJournalNodeCount()) {
       liveState.transitionTo(AcquisitionPhase.JOURNAL_NODES);
     } else if (liveState.getNameNodeSize() < HDFSConstants.TOTAL_NAME_NODES) {
@@ -645,38 +661,5 @@ public class HdfsScheduler implements org.apache.mesos.Scheduler, Runnable {
       }
     }
     return false;
-  }
-
-  private void reconcileTasks(SchedulerDriver driver) {
-    // TODO (elingg) run this method repeatedly with exponential backoff in the case that it takes
-    // time for
-    // different slaves to reregister upon master failover.
-    driver.reconcileTasks(Collections.<Protos.TaskStatus>emptyList());
-    Timer timer = new Timer();
-    timer.schedule(new ReconcileStateTask(), hdfsFrameworkConfig.getReconciliationTimeout() * SECONDS_FROM_MILLIS);
-  }
-
-  private class ReconcileStateTask extends TimerTask {
-
-    @Override
-    public void run() {
-      log.info("Current persistent state:");
-      log.info(String.format("JournalNodes: %s, %s", persistenceStore.getJournalNodes(),
-        persistenceStore.getJournalNodeTaskNames()));
-      log.info(String.format("NameNodes: %s, %s", persistenceStore.getNameNodes(),
-        persistenceStore.getNameNodeTaskNames()));
-      log.info(String.format("DataNodes: %s", persistenceStore.getDataNodes()));
-
-      Set<String> taskIds = persistenceStore.getAllTaskIds();
-      Set<String> runningTaskIds = liveState.getRunningTasks().keySet();
-
-      for (String taskId : taskIds) {
-        if (taskId != null && !runningTaskIds.contains(taskId)) {
-          log.info("Removing task id: " + taskId);
-          persistenceStore.removeTaskId(taskId);
-        }
-      }
-      correctCurrentPhase();
-    }
   }
 }

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/Reconciler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/Reconciler.java
@@ -1,0 +1,107 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.Protos.TaskState;
+import org.apache.mesos.Protos.TaskStatus;
+import org.apache.mesos.Protos;
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+import java.util.Set;
+
+public class Reconciler implements Observer {
+  private final Log log = LogFactory.getLog(HdfsScheduler.class);
+  private IPersistentStateStore store;
+  private Set<String> pendingTasks;
+
+  public Reconciler(IPersistentStateStore pStore) {
+    store = pStore;
+    pendingTasks = new HashSet<String>();
+  }
+
+  public void reconcile(SchedulerDriver driver) {
+    pendingTasks = store.getAllTaskIds();
+    logPendingTasks();
+    ExplicitlyReconcileTasks(driver);
+    ImplicitlyReconcileTasks(driver);
+  }
+
+  public void update(Observable obs, Object obj) {
+    TaskStatus status = (TaskStatus)obj;
+
+    String taskId = status.getTaskId().getValue();
+    log.info("Received task update for: " + taskId);
+
+    if(!complete()) {
+      log.info("Reconciliation is NOT complete");
+
+      if (taskIsPending(taskId)) {
+        log.info(String.format("Reconciling Task '%s'.", taskId));
+        pendingTasks.remove(taskId);
+      } else {
+        log.info(String.format("Task '%s' is not pending reconciliation.", taskId));
+      }
+
+      logPendingTasks();
+
+      if (complete()) {
+        log.info("Reconciliation is complete");
+      }
+    }
+  }
+
+  private boolean taskIsPending(String taskId) {
+    for (String t : pendingTasks) {
+      if (t.equals(taskId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public boolean complete() {
+    if (pendingTasks.size() > 0) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private void logPendingTasks() {
+    log.info("=========================================");
+    log.info("pendingTasks size: " + pendingTasks.size());
+    for (String t : pendingTasks) {
+        log.info(t);
+    }
+    log.info("=========================================");
+  }
+
+  private void ImplicitlyReconcileTasks(SchedulerDriver driver) {
+    log.info("Implicitly Reconciling Tasks");
+    driver.reconcileTasks(Collections.<TaskStatus>emptyList());
+  }
+
+  private void ExplicitlyReconcileTasks(SchedulerDriver driver) {
+    log.info("Explicitly Reconciling Tasks");
+    List<TaskStatus> tasks  = new ArrayList<TaskStatus>();
+
+    for (String id : pendingTasks) {
+      Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue(id).build();
+      TaskStatus taskStatus = TaskStatus.newBuilder()
+        .setTaskId(taskId)
+        .setState(TaskState.TASK_RUNNING).build();
+
+      tasks.add(taskStatus);
+    }
+
+    driver.reconcileTasks(tasks);
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/LiveState.java
@@ -104,6 +104,12 @@ public class LiveState {
   }
 
   public void transitionTo(AcquisitionPhase phase) {
+    if (currentAcquisitionPhase.equals(phase)) {
+      log.info(String.format("Acquisition phase is already '%s'", currentAcquisitionPhase));
+      return;
+    }
+
+    log.info(String.format("Transitioning from acquisition phase '%s' to '%s'", currentAcquisitionPhase, phase));
     this.currentAcquisitionPhase = phase;
   }
 


### PR DESCRIPTION
We now do explicit and implicit reconciliation.  This improves startup
time because we no longer blindly wait 30s hoping reconciliation
completes.  This also fixes a correctness problem.  We were always
transitioning out of the Reconciliation acquisition phase regardless of
the status updates we received after 30s.  Now we don't exit
reconciliation until we receive all the needed status updates.

There are also design improvements: moving the reconciliation
implementation out of the Scheduler class, and using the Observer model
to receive status update notifications.

Example output from a reconciliation session is available here:
https://docs.google.com/document/d/1dCe-7LFnqsg_hZB3As31yGG2jkDMIrqlrp5wmmMp0jE/edit

Note reconciliation now takes less than 1s and is well logged.