### PR TITLE
Dockerize the hdfs mesos framework to be able to schedule as docker on marathon/chronos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM java:7-jdk
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
+    echo "deb http://repos.mesosphere.io/ubuntu trusty main" | tee /etc/apt/sources.list.d/mesosphere.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y --force-yes mesos=0.21.1-1.1.ubuntu1404
+
+ADD build/hdfs-mesos-0.1.3.tgz /hdfs/build/
+
+WORKDIR /hdfs/build/hdfs-mesos-0.1.3
+
+ENTRYPOINT ["/bin/bash", "-c", "echo 'Arguments: ' $0 $*; python bin/hdfs-start.py --mesos.conf.path=etc/hadoop/mesos-site.xml $0 $*"]
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Starting HDFS-Mesos
 2. `./bin/hdfs-mesos`
 3. Check the Mesos web console to wait until all tasks are RUNNING (monitor status in JN sandboxes)
 
+Dockerizing HDFS-Mesos
+--------------------------
+Dockerizing the HDFS-Mesos will let you provide the configure the mesos-site.xml at run time. This is more flexible way of using the same docker image with some fixed configuration and while running, configure it for specific mesos cluster.
+1. `sudo docker build -t hdfs-mesos .`
+2. `sudo docker push hdfs-mesos`
+
+Running the hdfs-mesos docker
+---------------------------
+Example run :- 
+
+1. `sudo docker run -t hdfs-mesos --net=host mesos.hdfs.framework.name=hdfs-test1 mesos.hdfs.zkfc.ha.zookeeper.quorum=localhost:2181 mesos.master.uri=zk://localhost:2181/mesos mesos.hdfs.state.zk=localhost:2181`
+
+
 Using HDFS
 --------------------------
 See some of the many HDFS tutorials out there for more details and explore the web UI at <br>`http://<ActiveNameNode>:50070`.</br>

--- a/bin/build-hdfs
+++ b/bin/build-hdfs
@@ -138,6 +138,7 @@ cp -R $BUILD_CACHE_DIR/$HADOOP_DIR/share/hadoop/hdfs/webapps $BUILD_DIR/$DIST/sh
 
 ## hdfs scheduler project needs
 cp $PROJ_DIR/bin/hdfs-mesos $BUILD_DIR/$DIST/bin
+cp $PROJ_DIR/bin/hdfs-start.py $BUILD_DIR/$DIST/bin
 cp $PROJ_DIR/hdfs-scheduler/build/libs/*-uber.jar $BUILD_DIR/$DIST/lib
 cp $BUILD_CACHE_DIR/$EXECUTOR.tgz $BUILD_DIR/$DIST
 cp $PROJ_DIR/conf/*.xml $BUILD_DIR/$DIST/etc/hadoop

--- a/bin/hdfs-start.py
+++ b/bin/hdfs-start.py
@@ -1,0 +1,55 @@
+import sys
+from optparse import OptionParser
+from subprocess import STDOUT, check_call
+import subprocess
+import shutil
+import xml.etree.ElementTree as ET
+
+def parse_args():
+  parser = OptionParser(usage="[options] [property=value]* ")
+  parser.add_option("--mesos.conf.path",  dest="cnfpath", default="none", help="config file path to configure before start")
+  (opts, args) = parser.parse_args()
+  return (opts, args)
+
+def findProperty(xmlElement, propertyName) :
+  for prop in xmlElement.findall("property"):
+     if(prop.find("name").text == propertyName):
+        return prop
+  return None;
+     
+
+def appendProperty(xmlElement, propertyName, description, value):
+  propertyElement = findProperty(xmlElement, propertyName);
+  if(None == propertyElement):
+      propertyElement = ET.SubElement(xmlElement, "property")
+      ET.SubElement(propertyElement, "name")
+      ET.SubElement(propertyElement, "description")
+      ET.SubElement(propertyElement, "value")  
+  propertyElement.find("name").text = propertyName
+  if(description):
+     propertyElement.find("description").text = description
+  propertyElement.find("value").text = value;
+  
+  
+
+def configure(opts, args):
+  cnfPath = opts.cnfpath
+  tree = ET.parse(cnfPath)
+  configElement = tree.getroot()
+  for a in args:
+     (name, value) = a.split('=')
+     appendProperty(configElement, name, "", value)
+  tree.write(cnfPath, xml_declaration=True,encoding='utf-8',
+           method="xml")
+  
+
+if __name__ == "__main__":
+  (opts, args) = parse_args()
+  configure(opts, args)
+  
+  cnfPath = opts.cnfpath
+  f = open(cnfPath, 'r')
+  print f.read()
+  subprocess.call("./bin/hdfs-mesos", shell=True)
+
+  


### PR DESCRIPTION
1. Adding the hdfs-start.py -  This calls the ./bin/hdfs-mesos, however expose the option to modify the given config file parameters with the run time arguments.
2. Writing a docker file
3. Executing the hdfs-start with the arguments passed while running the docker image.
