### PR TITLE
Add the support for defining the mesos constraints while running the hdfs framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ Note: This will also remove task state, so you will want to manually kill any ru
 7. On each slave with the new settings, start the mesos slave by running
 <br>`sudo service mesos-slave start`.</br>
 
+Applying mesos slave constraints (Optional)
+--------------------------
+1. In mesos-site.xml, add the configuration mesos.hdfs.constraints
+2. Set the value of configuration as ";" separated set of key:value pairs. Key and value has to be separated by the ":". Key represents the attribute name. Value can be exact match, less than or equal to, subset or value within the range for attribute of type text, scalar, set and range, respectively. For example:
+```sh
+<property>
+  <name>mesos.hdfs.constraints</name>
+  <value>zone:west,east;cpu:4;quality:optimized-disk;id:4</value>
+</property>
+
+"zone" is type of set with members {"west","east"}.
+"cpu" is type of scalar. 
+"quality" is type of text. 
+"id" may be type of range. 
+```
+
+
 Authentication with CRAM-MD5 (Optional)
 --------------------------
 1. In mesos-site.xml add the "mesos.hdfs.principal" and "mesos.hdfs.secret" properties. For example:

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -1,6 +1,8 @@
 package org.apache.mesos.hdfs.config;
 
 import com.google.inject.Singleton;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -8,6 +10,8 @@ import org.apache.hadoop.fs.Path;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -307,5 +311,22 @@ public class HdfsFrameworkConfig {
 
   public String getJreVersion() {
     return getConf().get("mesos.hdfs.jre-version", "jre1.7.0_76");
+  }
+  
+  public Map<String, String> getMesosSlaveConstraints() {
+    String constraints = getConf().get("mesos.hdfs.constraints");
+    Map<String, String> constraintsMap = new HashMap<String, String>();
+    if (!StringUtils.isBlank(constraints)) {
+      String[] constraintsPairs = constraints.split(";");
+      for (String pair : constraintsPairs) {
+        String[] keyValue = pair.split(":");
+        String key = keyValue[0];
+        String value = keyValue.length == 2 ? keyValue[1]
+            : keyValue.length == 1 ? "" : pair.substring(pair.indexOf(":"));
+        constraintsMap.put(key, value);
+      }
+    }
+
+    return constraintsMap;
   }
 }

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -1,7 +1,6 @@
 package org.apache.mesos.hdfs.config;
 
 import com.google.inject.Singleton;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -320,10 +319,12 @@ public class HdfsFrameworkConfig {
       String[] constraintsPairs = constraints.split(";");
       for (String pair : constraintsPairs) {
         String[] keyValue = pair.split(":");
-        String key = keyValue[0];
-        String value = keyValue.length == 2 ? keyValue[1]
-            : keyValue.length == 1 ? "" : pair.substring(pair.indexOf(":"));
-        constraintsMap.put(key, value);
+        if (keyValue.length > 0) {
+          String key = keyValue[0];
+          String value = keyValue.length == 1 ? "" : 
+             keyValue.length == 2 ? keyValue[1] : pair.substring(pair.indexOf(":"));
+          constraintsMap.put(key, value);
+        }
       }
     }
 

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsMesosConstraints.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsMesosConstraints.java
@@ -1,0 +1,104 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.mesos.Protos.Attribute;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Value.Range;
+
+/**
+ * HDFS Mesos offer constraints checker class implementation.
+ */
+public class HdfsMesosConstraints {
+
+  private final Map<String, String> constraints;
+
+  public HdfsMesosConstraints(Map<String, String> mesosSlaveConstraints) {
+    this.constraints = mesosSlaveConstraints;
+  }
+
+  public boolean constraintsAllow(Offer offer) {
+    List<Attribute> attributes = offer.getAttributesList();
+
+    for (Map.Entry<String, String> constraintEntry : this.constraints
+        .entrySet()) {
+      boolean found = false;
+      String constraintName = constraintEntry.getKey();
+      String constraintValue = constraintEntry.getValue();
+      for (Attribute attribute : attributes) {
+
+        if (attribute.getName().equals(constraintName)) {
+
+          switch (attribute.getType()) {
+          case RANGES:
+            if (attribute.hasRanges()) {
+              try {
+                Long value = Long.parseLong(constraintValue);
+                for (Range r : attribute.getRanges().getRangeList()) {
+                  if ((!r.hasBegin() || value >= r.getBegin())
+                      && (!r.hasEnd() || value <= r.getEnd())) {
+                    found = true;
+                    break;
+                  }
+                }
+              } catch (NumberFormatException e) {
+                found = false;
+                // not a range attribute
+              }
+            }
+            break;
+          case SCALAR:
+            if (attribute.hasScalar()) {
+              try {
+                if (attribute.getScalar().getValue() >= Double
+                    .parseDouble(constraintValue)) {
+                  found = true;
+                }
+              } catch (NumberFormatException e) {
+                found = false;
+                // not a scalar attribute
+              }
+            }
+            break;
+          case SET:
+            if (attribute.hasSet()) {
+              boolean isSubset = true;
+              for (String element : constraintValue.split("=")) {
+                if (!attribute.getSet().getItemList().contains(element)) {
+                  isSubset = false;
+                  break;
+                }
+              }
+
+              found = isSubset;
+            }
+            break;
+          case TEXT:
+            if (attribute.hasText()
+                && (!attribute.getText().hasValue() || attribute.getText()
+                    .getValue().equals(constraintValue))) {
+              found = true;
+              break;
+            }
+            break;
+          default:
+            break;
+
+          }
+
+        }
+
+        if (found) {
+          break;
+        }
+      }
+
+      if (!found) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsMesosConstraints.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsMesosConstraints.java
@@ -3,6 +3,9 @@ package org.apache.mesos.hdfs.scheduler;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.Value.Range;
@@ -12,7 +15,8 @@ import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
  * HDFS Mesos offer constraints checker class implementation.
  */
 public class HdfsMesosConstraints {
-
+  
+  private final Log log = LogFactory.getLog(HdfsMesosConstraints.class);
   private final HdfsFrameworkConfig config;
 
   public HdfsMesosConstraints(HdfsFrameworkConfig config) {
@@ -45,10 +49,10 @@ public class HdfsMesosConstraints {
                   }
                 }
               } catch (NumberFormatException e) {
-                // Offer attribute value is not castble to number. Found is already false.
-                // This is not error. It was just a trial.
-                // Setting it false explicitly again to avoid empty catch build error
-                found = false;
+                // Offer attribute value is not castble to number.
+                String msg = "Constraint value " + constraintValue + 
+                    " is not of type range for offer attribute " + constraintName; 
+                log.warn(msg, e);
               }
             } 
             break;
@@ -60,10 +64,10 @@ public class HdfsMesosConstraints {
                   found = true;
                 }
               } catch (NumberFormatException e) {                
-                // Offer attribute value is not castble to scalar. Found is already false.
-                // This is not error. It was just a trial.
-                // Setting it false explicitly again to avoid empty catch build error
-                found = false;
+                // Offer attribute value is not castble to scalar. 
+                String msg = "Constraint value \"" + constraintValue + 
+                "\" is not of type scalar for offer attribute " + constraintName;
+                log.warn(msg, e);
               }
             }
             break;

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -2,7 +2,6 @@ package org.apache.mesos.hdfs.scheduler;
 
 import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.mesos.MesosSchedulerDriver;
@@ -26,7 +25,6 @@ import org.apache.mesos.hdfs.state.PersistenceException;
 import org.apache.mesos.hdfs.state.IPersistentStateStore;
 import org.apache.mesos.hdfs.util.DnsResolver;
 import org.apache.mesos.hdfs.util.HDFSConstants;
-
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -43,10 +41,8 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
   private final HdfsMesosConstraints hdfsMesosConstraints;
   private final LiveState liveState;
   private final IPersistentStateStore persistenceStore;
-
   private final DnsResolver dnsResolver;
   private final Reconciler reconciler;
-
 
   @Inject
   public HdfsScheduler(HdfsFrameworkConfig config,
@@ -54,12 +50,11 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
 
     this.config = config;
     this.hdfsMesosConstraints 
-           = new HdfsMesosConstraints(this.config.getMesosSlaveConstraints());
+           = new HdfsMesosConstraints(this.config);
     this.liveState = liveState;
     this.persistenceStore = persistenceStore;
     this.dnsResolver = new DnsResolver(this, config);
     this.reconciler = new Reconciler(config, persistenceStore);
-
     addObserver(reconciler);
   }
 
@@ -225,7 +220,7 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
     // TODO (elingg) within each phase, accept offers based on the number of nodes you need
     boolean acceptedOffer = false;
     for (Offer offer : offers) {
-      if (!this.hdfsMesosConstraints.constraintsAllow(offer)) {
+      if (!hdfsMesosConstraints.constraintsAllow(offer)) {
         driver.declineOffer(offer.getId());
       } else if (acceptedOffer) {
         driver.declineOffer(offer.getId());

--- a/hdfs-scheduler/src/test/java/org/apache/mesos/hdfs/TestSchedularConstraints.java
+++ b/hdfs-scheduler/src/test/java/org/apache/mesos/hdfs/TestSchedularConstraints.java
@@ -1,0 +1,227 @@
+package org.apache.mesos.hdfs;
+
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Value.Type;
+import org.apache.mesos.SchedulerDriver;
+import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
+import org.apache.mesos.hdfs.scheduler.HdfsScheduler;
+import org.apache.mesos.hdfs.state.AcquisitionPhase;
+import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.hdfs.util.DnsResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+public class TestSchedularConstraints {
+
+  Configuration config = new Configuration();
+
+  private HdfsFrameworkConfig hdfsFrameworkConfig;
+
+  @Mock
+  SchedulerDriver driver;
+
+  @Mock
+  IPersistentStateStore persistenceStore;
+
+  @Mock
+  LiveState liveState;
+
+  @Mock
+  DnsResolver dnsResolver;
+
+  @Captor
+  ArgumentCaptor<Collection<Protos.TaskInfo>> taskInfosCapture;
+
+  HdfsScheduler scheduler;
+
+  @Test
+  public void acceptOffersWithConstraintMatch() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer offer = addAttribute(
+        createTestOfferBuilderWithResources(4, 5, 64 * 1024), "zone", "east",
+        Protos.Value.Type.TEXT).build();
+    config.set("mesos.hdfs.constraints", "zone:east");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).launchTasks(anyList(), taskInfosCapture.capture());
+  }
+
+  @Test
+  public void declineOffersWithNoConstraintMatch() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer offer = addAttribute(
+        createTestOfferBuilderWithResources(4, 5, 64 * 1024), "zone", "west",
+        Protos.Value.Type.TEXT).build();
+    config.set("mesos.hdfs.constraints", "zone:east");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).declineOffer(offer.getId());
+  }
+
+  @Test
+  public void acceptOffersWithConstraintMatchSet() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer offer = addAttribute(
+        createTestOfferBuilderWithResources(4, 5, 64 * 1024), "zone",
+        "west,east", Protos.Value.Type.SET).build();
+    config.set("mesos.hdfs.constraints", "zone:east");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).launchTasks(anyList(), taskInfosCapture.capture());
+  }
+
+  @Test
+  public void acceptOffersWithConstraintMatchScalar() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer offer = addAttribute(
+        createTestOfferBuilderWithResources(4, 5, 64 * 1024), "CPU",
+        "3.5", Protos.Value.Type.SCALAR).build();
+    config.set("mesos.hdfs.constraints", "CPU:3");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).launchTasks(anyList(), taskInfosCapture.capture());
+  }
+
+  @Test
+  public void acceptOffersWithConstraintMatchMultiple() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer.Builder builder = createTestOfferBuilderWithResources(4, 5, 64 * 1024);
+    builder = addAttribute(builder, "CPU", "3.5", Protos.Value.Type.SCALAR);
+    builder = addAttribute(builder, "ZONE", "west,east,north", Protos.Value.Type.SET);
+    builder = addAttribute(builder, "TYPE", "hi-end", Protos.Value.Type.TEXT);
+    
+    config.set("mesos.hdfs.constraints", "CPU:2;ZONE:west");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(builder.build()));
+
+    verify(driver, times(1)).launchTasks(anyList(), taskInfosCapture.capture());
+  }
+  
+  @Test
+  public void declineOffersWithNoConstraintMatchMultiple() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer.Builder builder = createTestOfferBuilderWithResources(4, 5, 64 * 1024);
+    builder = addAttribute(builder, "CPU", "3.5", Protos.Value.Type.SCALAR);
+    builder = addAttribute(builder, "ZONE", "west,east,north", Protos.Value.Type.SET);
+    builder = addAttribute(builder, "TYPE", "hi-end", Protos.Value.Type.TEXT);
+    
+    Protos.Offer offer = builder.build();
+    config.set("mesos.hdfs.constraints", "TYPE:low-end;ZONE:north");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).declineOffer(offer.getId());
+  }
+  
+  @Test
+  public void acceptOffersWithNoConstraintSpecified() {
+    when(liveState.getCurrentAcquisitionPhase()).thenReturn(
+        AcquisitionPhase.DATA_NODES);
+    Protos.Offer offer = addAttribute(
+        createTestOfferBuilderWithResources(4, 5, 64 * 1024), "zone", "east",
+        Protos.Value.Type.TEXT).build();
+    config.set("mesos.hdfs.constraints", "");
+    this.scheduler = new HdfsScheduler(hdfsFrameworkConfig, liveState,
+        persistenceStore);
+    scheduler.resourceOffers(driver, Lists.newArrayList(offer));
+
+    verify(driver, times(1)).launchTasks(anyList(), taskInfosCapture.capture());
+  }
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    hdfsFrameworkConfig = new HdfsFrameworkConfig(config);    
+  }
+
+  private Protos.OfferID createTestOfferId(int instanceNumber) {
+    return Protos.OfferID.newBuilder().setValue("offer" + instanceNumber)
+        .build();
+  }
+
+  private Protos.Offer.Builder createTestOfferBuilderWithResources(
+      int instanceNumber, double cpus, int mem) {
+    return Protos.Offer
+        .newBuilder()
+        .setId(createTestOfferId(instanceNumber))
+        .setFrameworkId(
+            Protos.FrameworkID.newBuilder().setValue("framework1").build())
+        .setSlaveId(
+            Protos.SlaveID.newBuilder().setValue("slave" + instanceNumber)
+                .build())
+        .setHostname("host" + instanceNumber)
+
+        .addAllResources(
+            Arrays
+                .asList(
+                    Protos.Resource
+                        .newBuilder()
+                        .setName("cpus")
+                        .setType(Protos.Value.Type.SCALAR)
+                        .setScalar(
+                            Protos.Value.Scalar.newBuilder().setValue(cpus)
+                                .build()).setRole("*").build(),
+                    Protos.Resource
+                        .newBuilder()
+                        .setName("mem")
+                        .setType(Protos.Value.Type.SCALAR)
+                        .setScalar(
+                            Protos.Value.Scalar.newBuilder().setValue(mem)
+                                .build()).setRole("*").build()));
+  }
+
+  private Protos.Offer.Builder addAttribute(Protos.Offer.Builder offerBuilder,
+      String attributeName, String value, Type t) {
+    return offerBuilder.addAttributes(Protos.Attribute
+        .newBuilder()
+        .setType(t)
+        .setName(attributeName)
+        .setText(
+            Protos.Value.Text.newBuilder()
+                .setValue(t == Protos.Value.Type.TEXT ? value : "").build())
+        .setScalar(
+            Protos.Value.Scalar
+                .newBuilder()
+                .setValue(
+                    t == Protos.Value.Type.SCALAR ? Double.parseDouble(value)
+                        : 0.0).build())
+        .setSet(
+            Protos.Value.Set
+                .newBuilder()
+                .addAllItem(
+                    new ArrayList<String>(Arrays.asList(value.split(","))))
+                .build()).build());
+  }
+}


### PR DESCRIPTION
Constraints can be defined as configuration : - mesos.hdfs.constraints in mesos-site.xml as ";" separated string.

key value can be separated by ":". 

Example constraint string - zone:east,west;cpu:3;portrange:3,10

zone is set with valid values -  east and west
cpu is scalar with value 3 and 
portrange is range [3-10]

Inspiration for the correctness - https://issues.apache.org/jira/browse/SPARK-6707

Testing - 

Add the constraints as per README in mesos-site.xml. Tested for two cases
1. If attributes are set on slave machines and no constraints have been specified, then tasks should be lauchable on any slave machines.
2. If attributes are set on slave machines and constraints have been specified, then tasks should lauch on machines which satisfy the constraints.

To apply the attribute on slave machines - read mesosphere configuration guide.
