### PR TITLE
Retry reconciliation with bounded exponential backoff

### DIFF
--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -32,10 +32,11 @@ public class HdfsFrameworkConfig {
 
   private static final double DEFAULT_JVM_OVERHEAD = 1.35;
   private static final int DEFAULT_JOURNAL_NODE_COUNT = 3;
-  private static final int DEFAULT_FAILOVER_TIMEOUT = 31449600;
+  private static final int DEFAULT_FAILOVER_TIMEOUT_SEC = 31449600;
   private static final int DEFAULT_ZK_TIME_MS = 20000;
-  private static final int DEFAULT_RECONCILIATION_TIMEOUT = 30;
-  private static final int DEFAULT_DEADNODE_TIMEOUT = 90;
+  private static final int DEFAULT_RECONCILIATION_TIMEOUT_SEC = 4;
+  private static final int DEFAULT_MAX_RECONCILIATION_TIMEOUT_SEC = 30;
+  private static final int DEFAULT_DEADNODE_TIMEOUT_SEC = 90;
 
   private final Log log = LogFactory.getLog(HdfsFrameworkConfig.class);
 
@@ -217,7 +218,7 @@ public class HdfsFrameworkConfig {
   }
 
   public long getFailoverTimeout() {
-    return getConf().getLong("mesos.failover.timeout.sec", DEFAULT_FAILOVER_TIMEOUT);
+    return getConf().getLong("mesos.failover.timeout.sec", DEFAULT_FAILOVER_TIMEOUT_SEC);
   }
 
   // TODO(elingg) Most likely this user name will change to HDFS
@@ -285,11 +286,15 @@ public class HdfsFrameworkConfig {
   }
 
   public int getReconciliationTimeout() {
-    return getConf().getInt("mesos.reconciliation.timeout.seconds", DEFAULT_RECONCILIATION_TIMEOUT);
+    return getConf().getInt("mesos.reconciliation.timeout.sec", DEFAULT_RECONCILIATION_TIMEOUT_SEC);
+  }
+
+  public int getMaxReconciliationTimeout() {
+    return getConf().getInt("mesos.max-reconciliation.timeout.sec", DEFAULT_MAX_RECONCILIATION_TIMEOUT_SEC);
   }
 
   public int getDeadNodeTimeout() {
-    return getConf().getInt("mesos.hdfs.deadnode.timeout.seconds", DEFAULT_DEADNODE_TIMEOUT);
+    return getConf().getInt("mesos.hdfs.deadnode.timeout.seconds", DEFAULT_DEADNODE_TIMEOUT_SEC);
   }
 
   public String getJreUrl() {

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/util/HDFSConstants.java
@@ -8,6 +8,7 @@ public final class HDFSConstants {
   // Total number of NameNodes
   // Note: We do not currently support more or less than 2 NameNodes
   public static final Integer TOTAL_NAME_NODES = 2;
+  public static final Integer MILLIS_FROM_SECONDS = 1000;
 
   // Messages
   public static final String NAME_NODE_INIT_MESSAGE = "-i";

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -63,7 +63,7 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
     this.liveState = liveState;
     this.persistenceStore = persistenceStore;
     this.dnsResolver = new DnsResolver(this, hdfsFrameworkConfig);
-    this.reconciler = new Reconciler(persistenceStore);
+    this.reconciler = new Reconciler(hdfsFrameworkConfig, persistenceStore);
 
     addObserver(reconciler);
   }


### PR DESCRIPTION
The reconciler now retries reconciliation until it completes.  A retry
means here that the Scheduler will request status updates
explicitly for Tasks for which it has not yet received updates. It will
also retry implicit reconciliation where it asks for updates on all
tasks.

In order to avoid overloading Mesos with status update requests, the
Scheduler exponentially backs off up to a maximum delay between update
request rounds.