### PR TITLE
Refactor Scheduler

### DIFF
--- a/bin/hdfs-mesos-namenode
+++ b/bin/hdfs-mesos-namenode
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo hdfs-mesos-namenode $1 $2 $3 $4 $5
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -17,6 +18,7 @@ fi
 trap "{ $DIR/hdfs-mesos-killtree "$$" ; exit 0; }" EXIT
 
 function bootstrap_standby() {
+  echo "Asked to bootstrap namenode"
   $DIR/hdfs zkfc -formatZK -force
   exec $DIR/hdfs namenode -bootstrapStandby -force
 }
@@ -28,10 +30,12 @@ function format_namenode() {
 }
 
 function initialize_shared_edits() {
+  echo "Asked to initialize shared edits"
   exec $DIR/hdfs namenode -initializeSharedEdits
 }
 
 function run_namenode() {
+  echo "Asked to run namenode"
   while [ true ] ; do
     $DIR/hdfs namenode
     sleep 10

--- a/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
+++ b/hdfs-commons/src/main/java/org/apache/mesos/hdfs/config/HdfsFrameworkConfig.java
@@ -123,29 +123,6 @@ public class HdfsFrameworkConfig {
     return getHadoopHeapSize();
   }
 
-  public int getTaskHeapSize(String taskName) {
-    int size;
-    switch (taskName) {
-      case "zkfc":
-        size = getZkfcHeapSize();
-        break;
-      case "namenode":
-        size = getNameNodeHeapSize();
-        break;
-      case "datanode":
-        size = getDataNodeHeapSize();
-        break;
-      case "journalnode":
-        size = getJournalNodeHeapSize();
-        break;
-      default:
-        final String msg = "Invalid request for heapsize for taskName = " + taskName;
-        log.error(msg);
-        throw new ConfigurationException(msg);
-    }
-    return size;
-  }
-
   public double getJvmOverhead() {
     return getConf().getDouble("mesos.hdfs.jvm.overhead", DEFAULT_JVM_OVERHEAD);
   }
@@ -207,6 +184,29 @@ public class HdfsFrameworkConfig {
         throw new ConfigurationException(msg);
     }
     return cpus;
+  }
+
+  public int getTaskHeapSize(String taskName) {
+    int size;
+    switch (taskName) {
+      case "zkfc":
+        size = getZkfcHeapSize();
+        break;
+      case "namenode":
+        size = getNameNodeHeapSize();
+        break;
+      case "datanode":
+        size = getDataNodeHeapSize();
+        break;
+      case "journalnode":
+        size = getJournalNodeHeapSize();
+        break;
+      default:
+        final String msg = "Invalid request for heapsize for taskName = " + taskName;
+        log.error(msg);
+        throw new ConfigurationException(msg);
+    }
+    return size;
   }
 
   public int getJournalNodeCount() {

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -183,6 +183,7 @@ public abstract class AbstractNodeExecutor implements Executor {
    * Starts a task's process so it goes into running state.
    */
   protected void startProcess(ExecutorDriver driver, Task task) {
+    log.info(String.format("Starting process: %s", task.getCmd()));
     reloadConfig();
     if (task.getProcess() == null) {
       try {

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
@@ -111,6 +111,9 @@ public class NameNodeExecutor extends AbstractNodeExecutor {
   public void frameworkMessage(ExecutorDriver driver, byte[] msg) {
     super.frameworkMessage(driver, msg);
     String messageStr = new String(msg, Charset.defaultCharset());
+
+    log.info(String.format("Received framework message: %s", messageStr));
+
     File nameDir = new File(hdfsFrameworkConfig.getDataDir() + "/name");
     if (messageStr.equals(HDFSConstants.NAME_NODE_INIT_MESSAGE)
         || messageStr.equals(HDFSConstants.NAME_NODE_BOOTSTRAP_MESSAGE)) {

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/DataNode.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/DataNode.java
@@ -1,0 +1,56 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.util.HDFSConstants;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * DataNode.
+ */
+public class DataNode extends HdfsNode {
+  private final Log log = LogFactory.getLog(DataNode.class);
+  private List<String> taskTypes = Arrays.asList(HDFSConstants.DATA_NODE_ID);
+  private String executorName = HDFSConstants.NODE_EXECUTOR_ID;
+
+  public DataNode(LiveState liveState, IPersistentStateStore persistentStore, HdfsFrameworkConfig config) {
+    super(liveState, persistentStore, config, HDFSConstants.DATA_NODE_ID);
+  }
+
+  public boolean evaluate(Offer offer) {
+    boolean accept = false;
+
+    if (offerNotEnoughResources(offer, config.getDataNodeCpus(), config.getDataNodeHeapSize())) {
+      log.info("Offer does not have enough resources");
+    } else {
+      List<String> deadDataNodes = persistenceStore.getDeadDataNodes();
+      // TODO (elingg) Relax this constraint to only wait for DN's when the number of DN's is small
+      // What number of DN's should we try to recover or should we remove this constraint
+      // entirely?
+      if (deadDataNodes.isEmpty()) {
+        if (persistenceStore.dataNodeRunningOnSlave(offer.getHostname())
+            || persistenceStore.nameNodeRunningOnSlave(offer.getHostname())
+            || persistenceStore.journalNodeRunningOnSlave(offer.getHostname())) {
+          log.info(String.format("Already running hdfs task on %s", offer.getHostname()));
+        } else {
+          accept = true;
+        }
+      } else if (deadDataNodes.contains(offer.getHostname())) {
+        accept = true;
+      }
+    }
+
+    return accept;
+  }
+
+  public void launch(SchedulerDriver driver, Offer offer) {
+    launch(driver, offer, name, taskTypes, executorName);
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsNode.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsNode.java
@@ -1,0 +1,239 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import com.google.protobuf.ByteString;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.util.HDFSConstants;
+import org.apache.mesos.Protos.CommandInfo;
+import org.apache.mesos.Protos.Environment;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * HdfsNode base class. 
+ */
+public abstract class HdfsNode implements IOfferEvaluator, ILauncher {
+  private final Log log = LogFactory.getLog(HdfsNode.class);
+  private final LiveState liveState;
+  private final ResourceFactory resourceFactory;
+
+  protected final HdfsFrameworkConfig config;
+  protected final IPersistentStateStore persistenceStore;
+  protected final String name;
+
+
+  public HdfsNode(LiveState liveState, IPersistentStateStore persistentStore, HdfsFrameworkConfig config, String name) {
+    this.liveState = liveState;
+    this.persistenceStore = persistentStore;
+    this.config = config;
+    this.name = name;
+    this.resourceFactory = new ResourceFactory(config.getHdfsRole());
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  protected void launch(
+      SchedulerDriver driver,
+      Offer offer,
+      String nodeName,
+      List<String> taskTypes,
+      String executorName) {
+
+    List<TaskInfo> tasks = getTasks(driver, offer, nodeName, taskTypes, executorName);
+    launchNode(driver, offer, tasks);
+  }
+
+  private void launchNode(SchedulerDriver driver, Offer offer, List<TaskInfo> tasks) {
+    driver.launchTasks(Arrays.asList(offer.getId()), tasks);
+  }
+
+  private List<TaskInfo> getTasks(SchedulerDriver driver, Offer offer,
+      String nodeName, List<String> taskTypes, String executorName) {
+    // nodeName is the type of executor to launch
+    // executorName is to distinguish different types of nodes
+    // taskType is the type of task in mesos to launch on the node
+    // taskName is a name chosen to identify the task in mesos and mesos-dns (if used)
+    log.info(String.format("Launching node of type %s with tasks %s", nodeName, taskTypes.toString()));
+
+    String taskIdName = String.format("%s.%s.%d", nodeName, executorName, System.currentTimeMillis());
+
+    ExecutorInfo executorInfo = createExecutor(taskIdName, nodeName, executorName);
+
+    List<TaskInfo> tasks = new ArrayList<>();
+    for (String taskType : taskTypes) {
+      List<Resource> taskResources = getTaskResources(taskType);
+      String taskName = getNextTaskName(taskType);
+
+      TaskID taskId = TaskID.newBuilder()
+        .setValue(String.format("task.%s.%s", taskType, taskIdName))
+        .build();
+
+      TaskInfo task = TaskInfo.newBuilder()
+        .setExecutor(executorInfo)
+        .setName(taskName)
+        .setTaskId(taskId)
+        .setSlaveId(offer.getSlaveId())
+        .addAllResources(taskResources)
+        .setData(ByteString.copyFromUtf8(
+              String.format("bin/hdfs-mesos-%s", taskType)))
+        .build();
+      tasks.add(task);
+
+      liveState.addStagingTask(taskId);
+      persistenceStore.addHdfsNode(taskId, offer.getHostname(), taskType, taskName);
+    }
+
+    return tasks;
+  }
+
+  private ExecutorInfo createExecutor(String taskIdName, String nodeName, String executorName) {
+    int confServerPort = config.getConfigServerPort();
+
+    String cmd = "export JAVA_HOME=$MESOS_DIRECTORY/" + config.getJreVersion()
+      + " && env ; cd hdfs-mesos-* && "
+      + "exec `if [ -z \"$JAVA_HOME\" ]; then echo java; "
+      + "else echo $JAVA_HOME/bin/java; fi` "
+      + "$HADOOP_OPTS "
+      + "$EXECUTOR_OPTS "
+      + "-cp lib/*.jar org.apache.mesos.hdfs.executor." + executorName;
+
+    return ExecutorInfo
+      .newBuilder()
+      .setName(nodeName + " executor")
+      .setExecutorId(ExecutorID.newBuilder().setValue("executor." + taskIdName).build())
+      .addAllResources(getExecutorResources())
+      .setCommand(
+        CommandInfo
+          .newBuilder()
+          .addAllUris(
+            Arrays.asList(
+              CommandInfo.URI
+                .newBuilder()
+                .setValue(
+                  String.format("http://%s:%d/%s", config.getFrameworkHostAddress(),
+                    confServerPort,
+                    HDFSConstants.HDFS_BINARY_FILE_NAME))
+                .build(),
+              CommandInfo.URI
+                .newBuilder()
+                .setValue(
+                  String.format("http://%s:%d/%s", config.getFrameworkHostAddress(),
+                    confServerPort,
+                    HDFSConstants.HDFS_CONFIG_FILE_NAME))
+                .build(),
+              CommandInfo.URI
+                .newBuilder()
+                .setValue(config.getJreUrl())
+                .build()))
+          .setEnvironment(Environment.newBuilder()
+            .addAllVariables(Arrays.asList(
+              Environment.Variable.newBuilder()
+                .setName("LD_LIBRARY_PATH")
+                .setValue(config.getLdLibraryPath()).build(),
+              Environment.Variable.newBuilder()
+                .setName("HADOOP_OPTS")
+                .setValue(config.getJvmOpts()).build(),
+              Environment.Variable.newBuilder()
+                .setName("HADOOP_HEAPSIZE")
+                .setValue(String.format("%d", config.getHadoopHeapSize())).build(),
+              Environment.Variable.newBuilder()
+                .setName("HADOOP_NAMENODE_OPTS")
+                .setValue("-Xmx" + config.getNameNodeHeapSize()
+                  + "m -Xms" + config.getNameNodeHeapSize() + "m").build(),
+              Environment.Variable.newBuilder()
+                .setName("HADOOP_DATANODE_OPTS")
+                .setValue("-Xmx" + config.getDataNodeHeapSize()
+                  + "m -Xms" + config.getDataNodeHeapSize() + "m").build(),
+              Environment.Variable.newBuilder()
+                .setName("EXECUTOR_OPTS")
+                .setValue("-Xmx" + config.getExecutorHeap()
+                  + "m -Xms" + config.getExecutorHeap() + "m").build())))
+          .setValue(cmd).build())
+      .build();
+  }
+
+  private List<Resource> getTaskResources(String taskName) {
+    double cpu = config.getTaskCpus(taskName);
+    double mem = config.getTaskHeapSize(taskName) * config.getJvmOverhead();
+
+    List<Resource> resources = new ArrayList<Resource>();
+    resources.add(resourceFactory.createCpuResource(cpu));
+    resources.add(resourceFactory.createMemResource(mem));
+
+    return resources;
+  }
+
+  private String getNextTaskName(String taskType) {
+    if (taskType.equals(HDFSConstants.NAME_NODE_ID)) {
+      Collection<String> nameNodeTaskNames = persistenceStore.getNameNodeTaskNames().values();
+      for (int i = 1; i <= HDFSConstants.TOTAL_NAME_NODES; i++) {
+        if (!nameNodeTaskNames.contains(HDFSConstants.NAME_NODE_ID + i)) {
+          return HDFSConstants.NAME_NODE_ID + i;
+        }
+      }
+
+      String errorStr = "Cluster is in inconsistent state. " +
+        "Trying to launch more namenodes, but they are all already running.";
+      log.error(errorStr);
+      throw new SchedulerException(errorStr);
+    }
+
+    if (taskType.equals(HDFSConstants.JOURNAL_NODE_ID)) {
+      Collection<String> journalNodeTaskNames = persistenceStore.getJournalNodeTaskNames().values();
+      for (int i = 1; i <= config.getJournalNodeCount(); i++) {
+        if (!journalNodeTaskNames.contains(HDFSConstants.JOURNAL_NODE_ID + i)) {
+          return HDFSConstants.JOURNAL_NODE_ID + i;
+        }
+      }
+
+      String errorStr = "Cluster is in inconsistent state. " +
+        "Trying to launch more journalnodes, but they all are already running.";
+      log.error(errorStr);
+      throw new SchedulerException(errorStr);
+    }
+
+    return taskType;
+  }
+
+  private List<Resource> getExecutorResources() {
+    double cpu = config.getExecutorCpus();
+    double mem = config.getExecutorHeap() * config.getJvmOverhead();
+
+    return Arrays.asList(
+      resourceFactory.createCpuResource(cpu),
+      resourceFactory.createMemResource(mem));
+  }
+
+  protected boolean offerNotEnoughResources(Offer offer, double cpus, int mem) {
+    for (Resource offerResource : offer.getResourcesList()) {
+      if (offerResource.getName().equals("cpus") &&
+        cpus + config.getExecutorCpus() > offerResource.getScalar().getValue()) {
+        return true;
+      }
+
+      if (offerResource.getName().equals("mem") &&
+        (mem * config.getJvmOverhead())
+          + (config.getExecutorHeap() * config.getJvmOverhead())
+          > offerResource.getScalar().getValue()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/ILauncher.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/ILauncher.java
@@ -1,0 +1,11 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.SchedulerDriver;
+
+/**
+ * ILauncher interface.
+ */
+public interface ILauncher {
+  public void launch(SchedulerDriver driver, Offer offer);
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/IOfferEvaluator.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/IOfferEvaluator.java
@@ -1,0 +1,11 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.mesos.Protos.Offer;
+
+/**
+ * IOfferEvaluator interface. 
+ */
+public interface IOfferEvaluator {
+  public boolean evaluate(Offer offer);
+}
+

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/JournalNode.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/JournalNode.java
@@ -1,0 +1,60 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.util.HDFSConstants;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * JournalNode.
+ */
+public class JournalNode extends HdfsNode {
+  private final Log log = LogFactory.getLog(JournalNode.class);
+  private List<String> taskTypes = Arrays.asList(HDFSConstants.JOURNAL_NODE_ID);
+  private String executorName = HDFSConstants.NODE_EXECUTOR_ID;
+
+  public JournalNode(LiveState liveState, IPersistentStateStore persistentStore, HdfsFrameworkConfig config) {
+    super(liveState, persistentStore, config, HDFSConstants.JOURNAL_NODE_ID);
+  }
+
+
+  public boolean evaluate(Offer offer) {
+    boolean accept = false;
+
+    if (offerNotEnoughResources(offer, config.getJournalNodeCpus(), config.getJournalNodeHeapSize())) {
+      log.info("Offer does not have enough resources");
+    } else {
+      List<String> deadJournalNodes = persistenceStore.getDeadJournalNodes();
+
+      log.info(deadJournalNodes);
+
+      if (deadJournalNodes.isEmpty()) {
+        if (persistenceStore.getJournalNodes().size() == config.getJournalNodeCount()) {
+          log.info(String.format("Already running %s journalnodes", config.getJournalNodeCount()));
+        } else if (persistenceStore.journalNodeRunningOnSlave(offer.getHostname())) {
+          log.info(String.format("Already running journalnode on %s", offer.getHostname()));
+        } else if (persistenceStore.dataNodeRunningOnSlave(offer.getHostname())) {
+          log.info(String.format("Cannot colocate journalnode and datanode on %s",
+                offer.getHostname()));
+        } else {
+          accept = true;
+        }
+      } else if (deadJournalNodes.contains(offer.getHostname())) {
+        accept = true;
+      }
+    }
+
+    return accept;
+  }
+
+  public void launch(SchedulerDriver driver, Offer offer) {
+    launch(driver, offer, name, taskTypes, executorName);
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/NameNode.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/NameNode.java
@@ -1,0 +1,70 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.hdfs.config.HdfsFrameworkConfig;
+import org.apache.mesos.hdfs.state.IPersistentStateStore;
+import org.apache.mesos.hdfs.state.LiveState;
+import org.apache.mesos.hdfs.util.DnsResolver;
+import org.apache.mesos.hdfs.util.HDFSConstants;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.SchedulerDriver;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * HDFS Mesos Framework Scheduler class implementation.
+ */
+public class NameNode extends HdfsNode {
+  private final Log log = LogFactory.getLog(NameNode.class);
+  private List<String> taskTypes = Arrays.asList(HDFSConstants.NAME_NODE_ID, HDFSConstants.ZKFC_NODE_ID);
+  private String executorName = HDFSConstants.NAME_NODE_EXECUTOR_ID;
+  private DnsResolver dnsResolver;
+
+  public NameNode(
+      LiveState liveState,
+      IPersistentStateStore persistentStore,
+      DnsResolver dnsResolver,
+      HdfsFrameworkConfig config) {
+    super(liveState, persistentStore, config, HDFSConstants.NAME_NODE_ID);
+    this.dnsResolver = dnsResolver;
+  }
+
+  public boolean evaluate(Offer offer) {
+    boolean accept = false;
+
+    if (dnsResolver.journalNodesResolvable()) {
+      if (offerNotEnoughResources(offer,
+            (config.getNameNodeCpus() + config.getZkfcCpus()),
+            (config.getNameNodeHeapSize() + config.getZkfcHeapSize()))) {
+        log.info("Offer does not have enough resources");
+      } else {
+        List<String> deadNameNodes = persistenceStore.getDeadNameNodes();
+
+        if (deadNameNodes.isEmpty()) {
+          if (persistenceStore.getNameNodes().size() == HDFSConstants.TOTAL_NAME_NODES) {
+            log.info(String.format("Already running %s namenodes", HDFSConstants.TOTAL_NAME_NODES));
+          } else if (persistenceStore.nameNodeRunningOnSlave(offer.getHostname())) {
+            log.info(String.format("Already running namenode on %s", offer.getHostname()));
+          } else if (persistenceStore.dataNodeRunningOnSlave(offer.getHostname())) {
+            log.info(String.format("Cannot colocate namenode and datanode on %s", offer.getHostname()));
+          } else if (!persistenceStore.journalNodeRunningOnSlave(offer.getHostname())) {
+            log.info(String.format("We need to coloate the namenode with a journalnode and there is"
+                  + "no journalnode running on this host. %s", offer.getHostname()));
+          } else {
+            accept = true;
+          }
+        } else if (deadNameNodes.contains(offer.getHostname())) {
+          accept = true;
+        }
+      }
+    }
+
+    return accept;
+  }
+
+  public void launch(SchedulerDriver driver, Offer offer) {
+    launch(driver, offer, name, taskTypes, executorName);
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/NodeLauncher.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/NodeLauncher.java
@@ -1,0 +1,33 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.SchedulerDriver;
+
+/**
+ * NodeLauncher. 
+ */
+public class NodeLauncher {
+  private final Log log = LogFactory.getLog(NodeLauncher.class);
+
+  public boolean launch(SchedulerDriver driver, HdfsNode node, Offer offer) {
+    String nodeName = node.getName();
+    OfferID offerId = offer.getId();
+
+    log.info(String.format("Node: %s, evaluating offer: %s", nodeName, offerId));
+    boolean acceptOffer = node.evaluate(offer);
+
+    if (acceptOffer) {
+      log.info(String.format("Node: %s, accepting offer: %s", nodeName, offerId));
+      node.launch(driver, offer);
+    } else {
+      log.info(String.format("Node: %s, declining offer: %s", nodeName, offerId));
+      driver.declineOffer(offerId);
+    }
+
+    return acceptOffer;
+  }
+}

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/ResourceFactory.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/ResourceFactory.java
@@ -1,0 +1,46 @@
+package org.apache.mesos.hdfs.scheduler;
+
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.Value;
+
+/**
+ * Factory for generating Resources to launch HDFS Nodes.
+ */
+public class ResourceFactory {
+  private String role;
+
+  public ResourceFactory(String role) {
+    this.role = role;
+  }
+
+  public Resource createCpuResource(double value) {
+    return createScalarResource("cpus", value);
+  }
+
+  public Resource createMemResource(double value) {
+    return createScalarResource("mem", value);
+  }
+
+  public Resource createPortResource(long begin, long end) {
+    return createRangeResource("ports", begin, end);
+  }
+
+  private Resource createScalarResource(String name, double value) {
+    return Resource.newBuilder()
+      .setName(name)
+      .setType(Value.Type.SCALAR)
+      .setScalar(Value.Scalar.newBuilder()
+          .setValue(value).build())
+      .setRole(role)
+      .build();
+  }
+
+  private Resource createRangeResource(String name, long begin, long end) {
+    Value.Range range = Value.Range.newBuilder().setBegin(begin).setEnd(end).build();
+    return Resource.newBuilder()
+      .setName(name)
+      .setType(Value.Type.RANGES)
+      .setRanges(Value.Ranges.newBuilder().addRange(range))
+      .build();
+  }
+}


### PR DESCRIPTION
This change makes the Scheduler adopt a more object-oriented style.  The
different node types get their own classes and inherit from a base
class.  That base class requires implementation of a couple interfaces
allowing for a consistent pattern of evaluating and accepting/rejecting
offers.

A significant amount of logic is removed from the Scheduler class itself
and placed in the Node class hierarchy.  Additional refactoring work is
still needed espcially in the HdfsNode class, but this change produces
a significant restructure of the Scheduler.

It's a large change, so as a suggestion one might want to approach the code like this.

1) Look at resourceOffers in the HdfsScheduler.  You'll see the creation of the different node types as well as their launching through the nodeLauncher object.

2) Look at the nodeLauncher to see the consistent pattern of offer evaluation and accepting/rejecting offers.

3) Look at the JournalNode, NameNode, DataNode, and HdfsNode classes.  The majority of the logic which was in the HdfsScheduler class is now here.  In particular each of the concrete (non-abstract) classes implements the two required interfaces for the offer evaluation and node launching behavior.  The tryToLaunchXNode functions have had their logic placed in relevant XNode classes.   There is still some logic in the HdfsNode base class which shouldn't be there.  Sometimes it refers to a particular kind of node, and this logic should be moved to the specific Node classes in future refactors.

Testing: As usual I tested on DCOS and Mesos clusters.  Automated tests on DCOS all passed.  Killing all types of Nodes in conjunction with the Scheduler and singly returned to a healthy state.