### PR TITLE
Run away zkfc fix

### DIFF
--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/AbstractNodeExecutor.java
@@ -184,7 +184,6 @@ public abstract class AbstractNodeExecutor implements Executor {
   }
 
   private void shutdownExecutor(ExecutorDriver driver, int statusCode, String message, Exception e) {
-    shutdown(driver);
     if (StringUtils.isNotBlank(message)) {
       log.fatal(message, e);
     }
@@ -201,7 +200,6 @@ public abstract class AbstractNodeExecutor implements Executor {
       try {
         ProcessBuilder processBuilder = new ProcessBuilder("sh", "-c", task.getCmd());
         processBuilder.environment().putAll(createHdfsNodeEnvironment(task));
-
         task.setProcess(processBuilder.start());
         redirectProcess(task.getProcess());
       } catch (IOException e) {

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
@@ -133,12 +133,30 @@ public class NameNodeExecutor extends AbstractNodeExecutor {
       }
       runCommand(driver, nameNodeTask, "bin/hdfs-mesos-namenode " + messageStr);
       startProcess(driver, nameNodeTask);
-      startProcess(driver, zkfcNodeTask);
+
+      if (!processRunning(zkfcNodeTask)) {
+        startProcess(driver, zkfcNodeTask);
+      }
+
       driver.sendStatusUpdate(TaskStatus.newBuilder()
         .setTaskId(nameNodeTask.getTaskInfo().getTaskId())
         .setState(TaskState.TASK_RUNNING)
         .setMessage(messageStr)
         .build());
     }
+  }
+
+  private boolean processRunning(Task task) {
+    boolean running = false;
+
+    if (task.getProcess() != null) {
+      try {
+        task.getProcess().exitValue();
+      } catch (IllegalThreadStateException e) {
+        // throws exception if still running
+        running = true;
+      }
+    }
+    return running;
   }
 }

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
@@ -134,12 +134,13 @@ public class NameNodeExecutor extends AbstractNodeExecutor {
         throw new ExecutorException(errorMsg);
       }
       runCommand(driver, nameNodeTask, "bin/hdfs-mesos-namenode " + messageStr);
-      startProcess(driver, nameNodeTask);
-
+      // todo:  (kgs) we need to separate out the launching of these tasks
+      if (!processRunning(nameNodeTask)) {
+        startProcess(driver, nameNodeTask);
+      }
       if (!processRunning(zkfcNodeTask)) {
         startProcess(driver, zkfcNodeTask);
       }
-
       driver.sendStatusUpdate(TaskStatus.newBuilder()
         .setTaskId(nameNodeTask.getTaskInfo().getTaskId())
         .setState(TaskState.TASK_RUNNING)

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/NameNodeExecutor.java
@@ -49,7 +49,6 @@ public class NameNodeExecutor extends AbstractNodeExecutor {
     System.exit(driver.run() == Status.DRIVER_STOPPED ? 0 : 1);
   }
 
-
   /**
    * Add tasks to the task list and then start the tasks in the following order.
    * 1) Start Journal Node

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/TaskShutdownHook.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/TaskShutdownHook.java
@@ -9,7 +9,7 @@ import org.apache.mesos.ExecutorDriver;
  */
 public class TaskShutdownHook implements Runnable {
 
-  private final Log log = LogFactory.getLog(NameNodeExecutor.class);
+  private final Log log = LogFactory.getLog(TaskShutdownHook.class);
 
   private Executor executor;
   private ExecutorDriver driver;

--- a/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/TaskShutdownHook.java
+++ b/hdfs-executor/src/main/java/org/apache/mesos/hdfs/executor/TaskShutdownHook.java
@@ -1,0 +1,27 @@
+package org.apache.mesos.hdfs.executor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.mesos.Executor;
+import org.apache.mesos.ExecutorDriver;
+
+/**
+ */
+public class TaskShutdownHook implements Runnable {
+
+  private final Log log = LogFactory.getLog(NameNodeExecutor.class);
+
+  private Executor executor;
+  private ExecutorDriver driver;
+
+  public TaskShutdownHook(Executor executor, ExecutorDriver driver) {
+    this.executor = executor;
+    this.driver = driver;
+  }
+
+  @Override
+  public void run() {
+    log.info("shutdown hook shutting down tasks");
+    executor.shutdown(this.driver);
+  }
+}


### PR DESCRIPTION
This eliminates the possibility of multiple zkfc nodes being created if a namenode is launched on the same executor.  The executor only gets 1 of each.

also, I added a shutdown hook... so if an executor is killed gracefully, it cleans all running task processes.  This is required for a certification.
