### PR TITLE
Invalidate framework ID if registration triggers an error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ subprojects {
     compile "org.slf4j:log4j-over-slf4j:${slf4jVer}"
     compile "org.slf4j:jcl-over-slf4j:${slf4jVer}"
     compile "ch.qos.logback:logback-classic:${logbackVer}"
+    compile "com.google.code.findbugs:annotations:3.0.0"
 
     compile("org.apache.hadoop:hadoop-common:${hadoopVer}") {
       exclude group: "log4j", module: "log4j"

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -66,8 +66,32 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
   @Override
   public void error(SchedulerDriver driver, String message) {
     log.error("Scheduler driver error: " + message);
+	// Currently, it's pretty hard to disambiguate this error from other causes of framework errors.
+    // Watch MESOS-2522 which will add a reason field for framework errors to help with this.
+    // For now the frameworkId is removed for all messages.
+    boolean removeFrameworkId = message.contains("re-register");
+    suicide(removeFrameworkId);
   }
 
+  /**
+    * Exits the JVM process, optionally deleting Marathon's FrameworkID
+    * from the backing persistence store.
+    *
+    * If `removeFrameworkId` is set, the next Marathon process elected
+    * leader will fail to find a stored FrameworkID and invoke `register`
+    * instead of `reregister`.  This is important because on certain kinds
+    * of framework errors (such as exceeding the framework failover timeout),
+    * the scheduler may never re-register with the saved FrameworkID until
+    * the leading Mesos master process is killed.
+    */
+  private void suicide(Boolean removeFrameworkId)  {
+    if (removeFrameworkId) 
+    {
+        persistenceStore.setFrameworkId(null);
+        System.exit(9);
+    }
+  }
+  
   @Override
   public void executorLost(SchedulerDriver driver, ExecutorID executorID, SlaveID slaveID,
     int status) {

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -66,7 +66,7 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
   @Override
   public void error(SchedulerDriver driver, String message) {
     log.error("Scheduler driver error: " + message);
-	// Currently, it's pretty hard to disambiguate this error from other causes of framework errors.
+    // Currently, it's pretty hard to disambiguate this error from other causes of framework errors.
     // Watch MESOS-2522 which will add a reason field for framework errors to help with this.
     // For now the frameworkId is removed for all messages.
     boolean removeFrameworkId = message.contains("re-register");
@@ -85,8 +85,7 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
     * the leading Mesos master process is killed.
     */
   private void suicide(Boolean removeFrameworkId)  {
-    if (removeFrameworkId) 
-    {
+    if (removeFrameworkId) {
         persistenceStore.setFrameworkId(null);
         System.exit(9);
     }

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Observable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * HDFS Mesos Framework Scheduler class implementation.
@@ -84,7 +85,9 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
     * the scheduler may never re-register with the saved FrameworkID until
     * the leading Mesos master process is killed.
     */
-  private void suicide(Boolean removeFrameworkId)  {
+  @SuppressFBWarnings(value = "DM_EXIT", 
+    justification = "Scheduler must be stopped")
+  private void suicide(Boolean removeFrameworkId) {
     if (removeFrameworkId) {
         persistenceStore.setFrameworkId(null);
         System.exit(9);

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/HdfsZkStore.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/HdfsZkStore.java
@@ -38,9 +38,12 @@ public class HdfsZkStore implements IHdfsStore {
     return value;
   }
 
-  public void setRawValueForId(String id, byte[] frameworkId) throws ExecutionException, InterruptedException {
+  public void setRawValueForId(String id, byte[] newRawValue) throws ExecutionException, InterruptedException {
     Variable value = state.fetch(id).get();
-    value = value.mutate(frameworkId);
+    if(newRawValue == null)
+        value = value.mutate(new byte[]{});
+    else
+        value = value.mutate(newRawValue);
     state.store(value).get();
   }
 

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/HdfsZkStore.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/HdfsZkStore.java
@@ -40,10 +40,11 @@ public class HdfsZkStore implements IHdfsStore {
 
   public void setRawValueForId(String id, byte[] newRawValue) throws ExecutionException, InterruptedException {
     Variable value = state.fetch(id).get();
-    if(newRawValue == null)
+    if (newRawValue == null) {
         value = value.mutate(new byte[]{});
-    else
+    } else {
         value = value.mutate(newRawValue);
+    }
     state.store(value).get();
   }
 

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/PersistentStateStore.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/PersistentStateStore.java
@@ -57,7 +57,10 @@ public class PersistentStateStore implements IPersistentStateStore {
   public void setFrameworkId(Protos.FrameworkID id) {
 
     try {
-      hdfsStore.setRawValueForId(FRAMEWORK_ID_KEY, id.toByteArray());
+      if(id != null)
+        hdfsStore.setRawValueForId(FRAMEWORK_ID_KEY, id.toByteArray());
+      else
+        hdfsStore.setRawValueForId(FRAMEWORK_ID_KEY, null);  
     } catch (ExecutionException | InterruptedException e) {
       logger.error("Unable to set frameworkId", e);
       throw new PersistenceException(e);

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/PersistentStateStore.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/state/PersistentStateStore.java
@@ -57,10 +57,11 @@ public class PersistentStateStore implements IPersistentStateStore {
   public void setFrameworkId(Protos.FrameworkID id) {
 
     try {
-      if(id != null)
+      if (id != null) {
         hdfsStore.setRawValueForId(FRAMEWORK_ID_KEY, id.toByteArray());
-      else
+      } else {
         hdfsStore.setRawValueForId(FRAMEWORK_ID_KEY, null);  
+      }
     } catch (ExecutionException | InterruptedException e) {
       logger.error("Unable to set frameworkId", e);
       throw new PersistenceException(e);


### PR DESCRIPTION
It's similar to problem already fixed in marathon:
https://github.com/mesosphere/marathon/issues/1316

I've have problem start mesos hdfs scheduler again if it is stopped for a while. I've must remove hdfs-mesos framework state from zookeeper, but this approach is pretty ugly and not necessary if my patch is applied. 

It is based on code from mesos marathon sources. If scheduler receives error from mesos that frameworkId is invalided during re-register, it clear only frameworkId in zookeeper and exit. After re-reun scheduler starts fine. If you run scheduler using marathon like me, this relaunch is done automatically, so scheduler starts fine after while.

Currently, it's pretty hard to disambiguate this error from other causes of framework errors, so I've also vote for issue MESOS-2522.