### PR TITLE
Set principal value when build FrameworkInfo

### DIFF
--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -231,8 +231,11 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
       .setFailoverTimeout(config.getFailoverTimeout())
       .setUser(config.getHdfsUser())
       .setRole(config.getHdfsRole())
-      .setPrincipal(config.getPrincipal())
       .setCheckpoint(true);
+
+    if (!"".equals(config.getPrincipal())) {
+      frameworkInfo.setPrincipal(config.getPrincipal());
+    }
 
     try {
       FrameworkID frameworkID = state.getFrameworkId();

--- a/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
+++ b/hdfs-scheduler/src/main/java/org/apache/mesos/hdfs/scheduler/HdfsScheduler.java
@@ -231,6 +231,7 @@ public class HdfsScheduler extends Observable implements org.apache.mesos.Schedu
       .setFailoverTimeout(config.getFailoverTimeout())
       .setUser(config.getHdfsUser())
       .setRole(config.getHdfsRole())
+      .setPrincipal(config.getPrincipal())
       .setCheckpoint(true);
 
     try {


### PR DESCRIPTION
Hi guys,

This PR depends on #175, to finish some works when mesos cluster enable ACL rules.

Our mesos cluster set ACL to control the framework register and run tasks, the rules always depends on roles and principal.

If we enable framework authentication, hdfs scheduler only set credential for the FrameworkInfo, but not set principal value, it does not work with ACL like this:

```
# credential
hdfs XXXXXXXXXXXXXXXXXXXXXX

# acl.json
{
  "permissive": false,
  "register_frameworks": [
    {
      "principals": {
        "values": [
          "hdfs"
        ]
      },
      "roles": {
        "values": [
          "hdfs"
        ]
      }
    }
  ], 
 ......
```

because principal always set to "" by default.

```
I1109 15:16:21.603461  5336 authenticator.cpp:92] Creating new server SASL connection
I1109 15:16:21.604151  5340 authenticator.cpp:197] Received SASL authentication start
I1109 15:16:21.604300  5340 authenticator.cpp:319] Authentication requires more steps
I1109 15:16:21.605181  5334 authenticator.cpp:225] Received SASL authentication step
I1109 15:16:21.605299  5334 authenticator.cpp:311] Authentication success
I1109 15:16:21.605419  5334 master.cpp:5168] Successfully authenticated principal 'hdfs' at scheduler-23b07469-9dad-4d32-a432-fe0d3167e4e4@10.90.4.65:54000
I1109 15:16:21.606125  5338 master.cpp:2179] Received SUBSCRIBE call for framework 'HDFS on Mesos' at scheduler-23b07469-9dad-4d32-a432-fe0d3167e4e4@10.90.4.65:54000
W1109 15:16:21.606194  5338 master.cpp:2186] Framework at scheduler-23b07469-9dad-4d32-a432-fe0d3167e4e4@10.90.4.65:54000 (authenticated as 'hdfs') does not set 'principal' in FrameworkInfo
I1109 15:16:21.606400  5338 master.cpp:1642] Authorizing framework principal '' to receive offers for role 'hdfs'
I1109 15:16:21.606530  5338 master.cpp:2226] Refusing subscription of framework 'HDFS on Mesos' at scheduler-23b07469-9dad-4d32-a432-fe0d3167e4e4@10.90.4.65:54000: Not authorized to use role 'hdfs'

```
